### PR TITLE
Improved error message parsing a non UTC date to epoch

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/joda/DateMathParser.java
+++ b/core/src/main/java/org/elasticsearch/common/joda/DateMathParser.java
@@ -192,7 +192,7 @@ public class DateMathParser {
         if (timeZone != null) {
             String format = dateTimeFormatter.format();
             // Non UTC time zones are not compatible with epoch formats
-            if (timeZone != DateTimeZone.UTC && format.equals("epoch_second") || format.equals("epoch_millis")) {
+            if (timeZone != DateTimeZone.UTC && (format.equals("epoch_second") || format.equals("epoch_millis"))) {
                 throw new ElasticsearchParseException("Format [{}] only supports UTC time zones", format);
             }
             parser = parser.withZone(timeZone);

--- a/core/src/main/java/org/elasticsearch/common/joda/DateMathParser.java
+++ b/core/src/main/java/org/elasticsearch/common/joda/DateMathParser.java
@@ -190,6 +190,11 @@ public class DateMathParser {
     private long parseDateTime(String value, DateTimeZone timeZone, boolean roundUpIfNoTime) {
         DateTimeFormatter parser = dateTimeFormatter.parser();
         if (timeZone != null) {
+            String format = dateTimeFormatter.format();
+            // Non UTC time zones are not compatible with epoch formats
+            if (timeZone != DateTimeZone.UTC && format.equals("epoch_second") || format.equals("epoch_millis")) {
+                throw new ElasticsearchParseException("Format [{}] only supports UTC time zones", format);
+            }
             parser = parser.withZone(timeZone);
         }
         try {

--- a/core/src/test/java/org/elasticsearch/common/joda/DateMathParserTests.java
+++ b/core/src/test/java/org/elasticsearch/common/joda/DateMathParserTests.java
@@ -307,6 +307,9 @@ public class DateMathParserTests extends ESTestCase {
             assertThat(e.getMessage(), containsString("Format [epoch_millis] only supports UTC time zones"));
         }
 
+        // Explicitly parsing a UTC timestamp is acceptable
+        parser.parse("1234567890123", () -> 42, false, DateTimeZone.forTimeZone(TimeZone.getTimeZone("UTC")));
+
         parser = new DateMathParser(Joda.forPattern("epoch_second"));
         try {
             parser.parse("1234567890123", () -> 42, false, DateTimeZone.forTimeZone(TimeZone.getTimeZone("CET")));
@@ -314,5 +317,8 @@ public class DateMathParserTests extends ESTestCase {
         } catch(ElasticsearchParseException e) {
             assertThat(e.getMessage(), containsString("Format [epoch_second] only supports UTC time zones"));
         }
+
+        // Explicitly parsing a UTC timestamp is acceptable
+        parser.parse("1234567890123", () -> 42, false, DateTimeZone.forTimeZone(TimeZone.getTimeZone("UTC")));
     }
 }

--- a/core/src/test/java/org/elasticsearch/common/joda/DateMathParserTests.java
+++ b/core/src/test/java/org/elasticsearch/common/joda/DateMathParserTests.java
@@ -304,8 +304,15 @@ public class DateMathParserTests extends ESTestCase {
             parser.parse("1234567890123", () -> 42, false, DateTimeZone.forTimeZone(TimeZone.getTimeZone("CET")));
             fail("Expected ElasticsearchParseException");
         } catch(ElasticsearchParseException e) {
-            assertThat(e.getMessage(), containsString("failed to parse date field"));
-            assertThat(e.getMessage(), containsString("with format [epoch_millis]"));
+            assertThat(e.getMessage(), containsString("Format [epoch_millis] only supports UTC time zones"));
+        }
+
+        parser = new DateMathParser(Joda.forPattern("epoch_second"));
+        try {
+            parser.parse("1234567890123", () -> 42, false, DateTimeZone.forTimeZone(TimeZone.getTimeZone("CET")));
+            fail("Expected ElasticsearchParseException");
+        } catch(ElasticsearchParseException e) {
+            assertThat(e.getMessage(), containsString("Format [epoch_second] only supports UTC time zones"));
         }
     }
 }

--- a/core/src/test/java/org/elasticsearch/common/joda/DateMathParserTests.java
+++ b/core/src/test/java/org/elasticsearch/common/joda/DateMathParserTests.java
@@ -299,26 +299,16 @@ public class DateMathParserTests extends ESTestCase {
     }
 
     public void testThatUnixTimestampMayNotHaveTimeZone() {
-        DateMathParser parser = new DateMathParser(Joda.forPattern("epoch_millis"));
-        try {
-            parser.parse("1234567890123", () -> 42, false, DateTimeZone.forTimeZone(TimeZone.getTimeZone("CET")));
-            fail("Expected ElasticsearchParseException");
-        } catch(ElasticsearchParseException e) {
-            assertThat(e.getMessage(), containsString("Format [epoch_millis] only supports UTC time zones"));
-        }
+        DateMathParser millisParser = new DateMathParser(Joda.forPattern("epoch_millis"));
+        expectThrows(ElasticsearchParseException.class,
+            () -> millisParser.parse("1234567890123", () -> 42, false, DateTimeZone.forTimeZone(TimeZone.getTimeZone("CET"))));
+
+        DateMathParser secondParser = new DateMathParser(Joda.forPattern("epoch_second"));
+        expectThrows(ElasticsearchParseException.class,
+            () -> secondParser.parse("1234567890123", () -> 42, false, DateTimeZone.forTimeZone(TimeZone.getTimeZone("CET"))));
 
         // Explicitly parsing a UTC timestamp is acceptable
-        parser.parse("1234567890123", () -> 42, false, DateTimeZone.forTimeZone(TimeZone.getTimeZone("UTC")));
-
-        parser = new DateMathParser(Joda.forPattern("epoch_second"));
-        try {
-            parser.parse("1234567890123", () -> 42, false, DateTimeZone.forTimeZone(TimeZone.getTimeZone("CET")));
-            fail("Expected ElasticsearchParseException");
-        } catch(ElasticsearchParseException e) {
-            assertThat(e.getMessage(), containsString("Format [epoch_second] only supports UTC time zones"));
-        }
-
-        // Explicitly parsing a UTC timestamp is acceptable
-        parser.parse("1234567890123", () -> 42, false, DateTimeZone.forTimeZone(TimeZone.getTimeZone("UTC")));
+        millisParser.parse("1234567890123", () -> 42, false, DateTimeZone.forTimeZone(TimeZone.getTimeZone("UTC")));
+        secondParser.parse("1234567890123", () -> 42, false, DateTimeZone.forTimeZone(TimeZone.getTimeZone("UTC")));
     }
 }


### PR DESCRIPTION
When a non-UTC timestamp was parsed to an epoch format, it would fail with the error message, **"failed to parse date field [1484334000000] with format [epoch_millis]"** This was incorrect as it was not a parse failure but an issue with non-UTC time zones being incompatible with the epoch format. 

The new error message reflects this