### PR TITLE
Add fuzzy transpositions parameter to multi match and query string qu…

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/MultiMatchQueryBuilder.java
@@ -22,6 +22,7 @@ package org.elasticsearch.index.query;
 import org.apache.lucene.search.FuzzyQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.Version;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.Strings;
@@ -55,12 +56,14 @@ public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQuery
     public static final int DEFAULT_PHRASE_SLOP = MatchQuery.DEFAULT_PHRASE_SLOP;
     public static final int DEFAULT_PREFIX_LENGTH = FuzzyQuery.defaultPrefixLength;
     public static final int DEFAULT_MAX_EXPANSIONS = FuzzyQuery.defaultMaxExpansions;
+    public static final boolean DEFAULT_FUZZY_TRANSPOSITIONS = FuzzyQuery.defaultTranspositions;
     public static final boolean DEFAULT_LENIENCY = MatchQuery.DEFAULT_LENIENCY;
     public static final MatchQuery.ZeroTermsQuery DEFAULT_ZERO_TERMS_QUERY = MatchQuery.DEFAULT_ZERO_TERMS_QUERY;
 
     private static final ParseField SLOP_FIELD = new ParseField("slop", "phrase_slop");
     private static final ParseField ZERO_TERMS_QUERY_FIELD = new ParseField("zero_terms_query");
     private static final ParseField LENIENT_FIELD = new ParseField("lenient");
+    private static final ParseField FUZZY_TRANSPOSITIONS_FIELD = new ParseField("fuzzy_transpositions");
     private static final ParseField CUTOFF_FREQUENCY_FIELD = new ParseField("cutoff_frequency");
     private static final ParseField TIE_BREAKER_FIELD = new ParseField("tie_breaker");
     private static final ParseField USE_DIS_MAX_FIELD = new ParseField("use_dis_max");
@@ -83,6 +86,7 @@ public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQuery
     private Fuzziness fuzziness;
     private int prefixLength = DEFAULT_PREFIX_LENGTH;
     private int maxExpansions = DEFAULT_MAX_EXPANSIONS;
+    private boolean fuzzyTranspositions = DEFAULT_FUZZY_TRANSPOSITIONS;
     private String minimumShouldMatch;
     private String fuzzyRewrite = null;
     private Boolean useDisMax;
@@ -213,6 +217,9 @@ public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQuery
         fuzziness = in.readOptionalWriteable(Fuzziness::new);
         prefixLength = in.readVInt();
         maxExpansions = in.readVInt();
+        if (in.getVersion().onOrAfter(Version.V_5_4_0_UNRELEASED)) {
+            fuzzyTranspositions = in.readBoolean();
+        }
         minimumShouldMatch = in.readOptionalString();
         fuzzyRewrite = in.readOptionalString();
         useDisMax = in.readOptionalBoolean();
@@ -237,6 +244,9 @@ public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQuery
         out.writeOptionalWriteable(fuzziness);
         out.writeVInt(prefixLength);
         out.writeVInt(maxExpansions);
+        if (out.getVersion().onOrAfter(Version.V_5_4_0_UNRELEASED)) {
+            out.writeBoolean(fuzzyTranspositions);
+        }
         out.writeOptionalString(minimumShouldMatch);
         out.writeOptionalString(fuzzyRewrite);
         out.writeOptionalBoolean(useDisMax);
@@ -395,6 +405,17 @@ public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQuery
         return maxExpansions;
     }
 
+    public MultiMatchQueryBuilder fuzzyTranspositions(boolean fuzzyTranspositions) {
+        this.fuzzyTranspositions = fuzzyTranspositions;
+        return this;
+    }
+
+    /** Gets the fuzzy query transposition setting. */
+    public boolean fuzzyTranspositions() {
+        return this.fuzzyTranspositions;
+    }
+
+
     public MultiMatchQueryBuilder minimumShouldMatch(String minimumShouldMatch) {
         this.minimumShouldMatch = minimumShouldMatch;
         return this;
@@ -539,6 +560,7 @@ public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQuery
         if (fuzzyRewrite != null) {
             builder.field(FUZZY_REWRITE_FIELD.getPreferredName(), fuzzyRewrite);
         }
+        builder.field(FUZZY_TRANSPOSITIONS_FIELD.getPreferredName(), fuzzyTranspositions);
         if (useDisMax != null) {
             builder.field(USE_DIS_MAX_FIELD.getPreferredName(), useDisMax);
         }
@@ -567,6 +589,7 @@ public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQuery
         int maxExpansions = DEFAULT_MAX_EXPANSIONS;
         Operator operator = DEFAULT_OPERATOR;
         String minimumShouldMatch = null;
+        boolean fuzzyTranspositions = FuzzyQuery.defaultTranspositions;
         String fuzzyRewrite = null;
         Boolean useDisMax = null;
         Float tieBreaker = null;
@@ -616,6 +639,8 @@ public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQuery
                     minimumShouldMatch = parser.textOrNull();
                 } else if (FUZZY_REWRITE_FIELD.match(currentFieldName)) {
                     fuzzyRewrite = parser.textOrNull();
+                } else if (FUZZY_TRANSPOSITIONS_FIELD.match(currentFieldName)){
+                    fuzzyTranspositions = parser.booleanValue();
                 } else if (USE_DIS_MAX_FIELD.match(currentFieldName)) {
                     useDisMax = parser.booleanValue();
                 } else if (TIE_BREAKER_FIELD.match(currentFieldName)) {
@@ -668,6 +693,7 @@ public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQuery
                 .useDisMax(useDisMax)
                 .lenient(lenient)
                 .maxExpansions(maxExpansions)
+                .fuzzyTranspositions(fuzzyTranspositions)
                 .minimumShouldMatch(minimumShouldMatch)
                 .operator(operator)
                 .prefixLength(prefixLength)
@@ -718,6 +744,7 @@ public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQuery
         multiMatchQuery.setFuzzyPrefixLength(prefixLength);
         multiMatchQuery.setMaxExpansions(maxExpansions);
         multiMatchQuery.setOccur(operator.toBooleanClauseOccur());
+        multiMatchQuery.setTranspositions(fuzzyTranspositions);
         if (fuzzyRewrite != null) {
             multiMatchQuery.setFuzzyRewriteMethod(QueryParsers.parseRewriteMethod(fuzzyRewrite, null));
         }
@@ -766,7 +793,7 @@ public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQuery
     protected int doHashCode() {
         return Objects.hash(value, fieldsBoosts, type, operator, analyzer, slop, fuzziness,
                 prefixLength, maxExpansions, minimumShouldMatch, fuzzyRewrite, useDisMax, tieBreaker, lenient,
-                cutoffFrequency, zeroTermsQuery);
+                cutoffFrequency, zeroTermsQuery, fuzzyTranspositions);
     }
 
     @Override
@@ -780,6 +807,7 @@ public class MultiMatchQueryBuilder extends AbstractQueryBuilder<MultiMatchQuery
                 Objects.equals(fuzziness, other.fuzziness) &&
                 Objects.equals(prefixLength, other.prefixLength) &&
                 Objects.equals(maxExpansions, other.maxExpansions) &&
+                Objects.equals(fuzzyTranspositions, other.fuzzyTranspositions) &&
                 Objects.equals(minimumShouldMatch, other.minimumShouldMatch) &&
                 Objects.equals(fuzzyRewrite, other.fuzzyRewrite) &&
                 Objects.equals(useDisMax, other.useDisMax) &&

--- a/core/src/test/java/org/elasticsearch/index/query/MultiMatchQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/MultiMatchQueryBuilderTests.java
@@ -111,6 +111,9 @@ public class MultiMatchQueryBuilderTests extends AbstractQueryTestCase<MultiMatc
         if (randomBoolean()) {
             query.fuzzyRewrite(getRandomRewriteMethod());
         }
+        if(randomBoolean()) {
+            query.fuzzyTranspositions(randomBoolean());
+        }
         if (randomBoolean()) {
             query.useDisMax(randomBoolean());
         }
@@ -231,19 +234,20 @@ public class MultiMatchQueryBuilderTests extends AbstractQueryTestCase<MultiMatc
     public void testFromJson() throws IOException {
         String json =
                 "{\n" +
-                "  \"multi_match\" : {\n" +
-                "    \"query\" : \"quick brown fox\",\n" +
-                "    \"fields\" : [ \"title^1.0\", \"title.original^1.0\", \"title.shingles^1.0\" ],\n" +
-                "    \"type\" : \"most_fields\",\n" +
-                "    \"operator\" : \"OR\",\n" +
-                "    \"slop\" : 0,\n" +
-                "    \"prefix_length\" : 0,\n" +
-                "    \"max_expansions\" : 50,\n" +
-                "    \"lenient\" : false,\n" +
-                "    \"zero_terms_query\" : \"NONE\",\n" +
-                "    \"boost\" : 1.0\n" +
-                "  }\n" +
-                "}";
+                        "  \"multi_match\" : {\n" +
+                        "    \"query\" : \"quick brown fox\",\n" +
+                        "    \"fields\" : [ \"title^1.0\", \"title.original^1.0\", \"title.shingles^1.0\" ],\n" +
+                        "    \"type\" : \"most_fields\",\n" +
+                        "    \"operator\" : \"OR\",\n" +
+                        "    \"slop\" : 0,\n" +
+                        "    \"prefix_length\" : 0,\n" +
+                        "    \"max_expansions\" : 50,\n" +
+                        "    \"fuzzy_transpositions\" : true,\n" +
+                        "    \"lenient\" : false,\n" +
+                        "    \"zero_terms_query\" : \"NONE\",\n" +
+                        "    \"boost\" : 1.0\n" +
+                        "  }\n" +
+                        "}";
 
         MultiMatchQueryBuilder parsed = (MultiMatchQueryBuilder) parseQuery(json);
         checkGeneratedJson(json, parsed);
@@ -259,17 +263,17 @@ public class MultiMatchQueryBuilderTests extends AbstractQueryTestCase<MultiMatc
      */
     public void testFuzzinessNotAllowedTypes() throws IOException {
         String[] notAllowedTypes = new String[]{ Type.CROSS_FIELDS.parseField().getPreferredName(),
-            Type.PHRASE.parseField().getPreferredName(), Type.PHRASE_PREFIX.parseField().getPreferredName()};
+                Type.PHRASE.parseField().getPreferredName(), Type.PHRASE_PREFIX.parseField().getPreferredName()};
         for (String type : notAllowedTypes) {
             String json =
                     "{\n" +
-                    "  \"multi_match\" : {\n" +
-                    "    \"query\" : \"quick brown fox\",\n" +
-                    "    \"fields\" : [ \"title^1.0\", \"title.original^1.0\", \"title.shingles^1.0\" ],\n" +
-                    "    \"type\" : \"" + type + "\",\n" +
-                    "    \"fuzziness\" : 1" +
-                    "  }\n" +
-                    "}";
+                            "  \"multi_match\" : {\n" +
+                            "    \"query\" : \"quick brown fox\",\n" +
+                            "    \"fields\" : [ \"title^1.0\", \"title.original^1.0\", \"title.shingles^1.0\" ],\n" +
+                            "    \"type\" : \"" + type + "\",\n" +
+                            "    \"fuzziness\" : 1" +
+                            "  }\n" +
+                            "}";
 
             ParsingException e = expectThrows(ParsingException.class, () -> parseQuery(json));
             assertEquals("Fuzziness not allowed for type [" + type +"]", e.getMessage());
@@ -279,11 +283,11 @@ public class MultiMatchQueryBuilderTests extends AbstractQueryTestCase<MultiMatc
     public void testQueryParameterArrayException() throws IOException {
         String json =
                 "{\n" +
-                "  \"multi_match\" : {\n" +
-                "    \"query\" : [\"quick\", \"brown\", \"fox\"]\n" +
-                "    \"fields\" : [ \"title^1.0\", \"title.original^1.0\", \"title.shingles^1.0\" ]" +
-                "  }\n" +
-                "}";
+                        "  \"multi_match\" : {\n" +
+                        "    \"query\" : [\"quick\", \"brown\", \"fox\"]\n" +
+                        "    \"fields\" : [ \"title^1.0\", \"title.original^1.0\", \"title.shingles^1.0\" ]" +
+                        "  }\n" +
+                        "}";
 
         ParsingException e = expectThrows(ParsingException.class, () -> parseQuery(json));
         assertEquals("[multi_match] unknown token [START_ARRAY] after [query]", e.getMessage());

--- a/core/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
+++ b/core/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
@@ -84,7 +84,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
         QueryStringQueryBuilder queryStringQueryBuilder = new QueryStringQueryBuilder(query);
         if (randomBoolean()) {
             queryStringQueryBuilder.defaultField(randomBoolean() ?
-                STRING_FIELD_NAME : randomAsciiOfLengthBetween(1, 10));
+                    STRING_FIELD_NAME : randomAsciiOfLengthBetween(1, 10));
         }
         if (randomBoolean()) {
             int numFields = randomIntBetween(1, 5);
@@ -197,9 +197,9 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
     public void testToQueryPhraseQuery() throws IOException {
         assumeTrue("test runs only when at least a type is registered", getCurrentTypes().length > 0);
         Query query = queryStringQuery("\"term1 term2\"")
-            .defaultField(STRING_FIELD_NAME)
-            .phraseSlop(3)
-            .toQuery(createShardContext());
+                .defaultField(STRING_FIELD_NAME)
+                .phraseSlop(3)
+                .toQuery(createShardContext());
         assertThat(query, instanceOf(DisjunctionMaxQuery.class));
         DisjunctionMaxQuery disjunctionMaxQuery = (DisjunctionMaxQuery) query;
         assertThat(disjunctionMaxQuery.getDisjuncts().size(), equalTo(1));
@@ -231,7 +231,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
         assertThat(boostQuery.getBoost(), equalTo(2.0f));
 
         queryStringQuery =
-            queryStringQuery("((" + STRING_FIELD_NAME + ":boosted^2) AND (" + STRING_FIELD_NAME + ":foo^1.5))^3");
+                queryStringQuery("((" + STRING_FIELD_NAME + ":boosted^2) AND (" + STRING_FIELD_NAME + ":foo^1.5))^3");
         query = queryStringQuery.toQuery(shardContext);
         assertThat(query, instanceOf(BoostQuery.class));
         boostQuery = (BoostQuery) query;
@@ -254,37 +254,37 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
     public void testToQueryMultipleTermsBooleanQuery() throws Exception {
         assumeTrue("test runs only when at least a type is registered", getCurrentTypes().length > 0);
         Query query = queryStringQuery("test1 test2").field(STRING_FIELD_NAME)
-            .useDisMax(false)
-            .toQuery(createShardContext());
+                .useDisMax(false)
+                .toQuery(createShardContext());
         assertThat(query, instanceOf(BooleanQuery.class));
         BooleanQuery bQuery = (BooleanQuery) query;
         assertThat(bQuery.clauses().size(), equalTo(2));
         assertThat(assertBooleanSubQuery(query, TermQuery.class, 0).getTerm(),
-            equalTo(new Term(STRING_FIELD_NAME, "test1")));
+                equalTo(new Term(STRING_FIELD_NAME, "test1")));
         assertThat(assertBooleanSubQuery(query, TermQuery.class, 1).getTerm(),
-            equalTo(new Term(STRING_FIELD_NAME, "test2")));
+                equalTo(new Term(STRING_FIELD_NAME, "test2")));
     }
 
     public void testToQueryMultipleFieldsBooleanQuery() throws Exception {
         assumeTrue("test runs only when at least a type is registered", getCurrentTypes().length > 0);
         Query query = queryStringQuery("test").field(STRING_FIELD_NAME)
-            .field(STRING_FIELD_NAME_2)
-            .useDisMax(false)
-            .toQuery(createShardContext());
+                .field(STRING_FIELD_NAME_2)
+                .useDisMax(false)
+                .toQuery(createShardContext());
         assertThat(query, instanceOf(BooleanQuery.class));
         BooleanQuery bQuery = (BooleanQuery) query;
         assertThat(bQuery.clauses().size(), equalTo(2));
         assertThat(assertBooleanSubQuery(query, TermQuery.class, 0).getTerm(),
-            equalTo(new Term(STRING_FIELD_NAME, "test")));
+                equalTo(new Term(STRING_FIELD_NAME, "test")));
         assertThat(assertBooleanSubQuery(query, TermQuery.class, 1).getTerm(),
-            equalTo(new Term(STRING_FIELD_NAME_2, "test")));
+                equalTo(new Term(STRING_FIELD_NAME_2, "test")));
     }
 
     public void testToQueryMultipleFieldsDisMaxQuery() throws Exception {
         assumeTrue("test runs only when at least a type is registered", getCurrentTypes().length > 0);
         Query query = queryStringQuery("test").field(STRING_FIELD_NAME).field(STRING_FIELD_NAME_2)
-            .useDisMax(true)
-            .toQuery(createShardContext());
+                .useDisMax(true)
+                .toQuery(createShardContext());
         assertThat(query, instanceOf(DisjunctionMaxQuery.class));
         DisjunctionMaxQuery disMaxQuery = (DisjunctionMaxQuery) query;
         List<Query> disjuncts = disMaxQuery.getDisjuncts();
@@ -299,17 +299,17 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
         BooleanQuery bQuery = (BooleanQuery) query;
         assertThat(bQuery.clauses().size(), equalTo(2));
         assertThat(assertBooleanSubQuery(query, TermQuery.class, 0).getTerm(),
-            equalTo(new Term(STRING_FIELD_NAME, "test")));
+                equalTo(new Term(STRING_FIELD_NAME, "test")));
         assertThat(assertBooleanSubQuery(query, TermQuery.class, 1).getTerm(),
-            equalTo(new Term(STRING_FIELD_NAME_2, "test")));
+                equalTo(new Term(STRING_FIELD_NAME_2, "test")));
     }
 
     public void testToQueryDisMaxQuery() throws Exception {
         assumeTrue("test runs only when at least a type is registered", getCurrentTypes().length > 0);
         Query query = queryStringQuery("test").field(STRING_FIELD_NAME, 2.2f)
-            .field(STRING_FIELD_NAME_2)
-            .useDisMax(true)
-            .toQuery(createShardContext());
+                .field(STRING_FIELD_NAME_2)
+                .useDisMax(true)
+                .toQuery(createShardContext());
         assertThat(query, instanceOf(DisjunctionMaxQuery.class));
         DisjunctionMaxQuery disMaxQuery = (DisjunctionMaxQuery) query;
         List<Query> disjuncts = disMaxQuery.getDisjuncts();
@@ -332,15 +332,15 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
             queryParser.reset(settings);
             Query query = queryParser.parse("first foo-bar-foobar* last");
             Query expectedQuery =
-                new BooleanQuery.Builder()
-                    .add(new BooleanClause(new TermQuery(new Term(STRING_FIELD_NAME, "first")), defaultOp))
-                    .add(new BooleanQuery.Builder()
-                        .add(new BooleanClause(new TermQuery(new Term(STRING_FIELD_NAME, "foo")), defaultOp))
-                        .add(new BooleanClause(new TermQuery(new Term(STRING_FIELD_NAME, "bar")), defaultOp))
-                        .add(new BooleanClause(new PrefixQuery(new Term(STRING_FIELD_NAME, "foobar")), defaultOp))
-                        .build(), defaultOp)
-                    .add(new BooleanClause(new TermQuery(new Term(STRING_FIELD_NAME, "last")), defaultOp))
-                    .build();
+                    new BooleanQuery.Builder()
+                            .add(new BooleanClause(new TermQuery(new Term(STRING_FIELD_NAME, "first")), defaultOp))
+                            .add(new BooleanQuery.Builder()
+                                    .add(new BooleanClause(new TermQuery(new Term(STRING_FIELD_NAME, "foo")), defaultOp))
+                                    .add(new BooleanClause(new TermQuery(new Term(STRING_FIELD_NAME, "bar")), defaultOp))
+                                    .add(new BooleanClause(new PrefixQuery(new Term(STRING_FIELD_NAME, "foobar")), defaultOp))
+                                    .build(), defaultOp)
+                            .add(new BooleanClause(new TermQuery(new Term(STRING_FIELD_NAME, "last")), defaultOp))
+                            .build();
             assertThat(query, Matchers.equalTo(expectedQuery));
         }
     }
@@ -362,24 +362,24 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
             Query query = queryParser.parse("first foo-bar-foobar* last");
 
             Query expectedQuery = new BooleanQuery.Builder()
-                .add(new BooleanClause(new SynonymQuery(new Term(STRING_FIELD_NAME, "first"),
-                    new Term(STRING_FIELD_NAME, "first")), defaultOp))
-                .add(new BooleanQuery.Builder()
-                    .add(new BooleanClause(new SynonymQuery(new Term(STRING_FIELD_NAME, "foo"),
-                        new Term(STRING_FIELD_NAME, "foo")), defaultOp))
-                    .add(new BooleanClause(new SynonymQuery(new Term(STRING_FIELD_NAME, "bar"),
-                        new Term(STRING_FIELD_NAME, "bar")), defaultOp))
+                    .add(new BooleanClause(new SynonymQuery(new Term(STRING_FIELD_NAME, "first"),
+                            new Term(STRING_FIELD_NAME, "first")), defaultOp))
                     .add(new BooleanQuery.Builder()
-                        .add(new BooleanClause(new PrefixQuery(new Term(STRING_FIELD_NAME, "foobar")),
-                            BooleanClause.Occur.SHOULD))
-                        .add(new BooleanClause(new PrefixQuery(new Term(STRING_FIELD_NAME, "foobar")),
-                            BooleanClause.Occur.SHOULD))
-                        .setDisableCoord(true)
-                        .build(), defaultOp)
-                    .build(), defaultOp)
-                .add(new BooleanClause(new SynonymQuery(new Term(STRING_FIELD_NAME, "last"),
-                    new Term(STRING_FIELD_NAME, "last")), defaultOp))
-                .build();
+                            .add(new BooleanClause(new SynonymQuery(new Term(STRING_FIELD_NAME, "foo"),
+                                    new Term(STRING_FIELD_NAME, "foo")), defaultOp))
+                            .add(new BooleanClause(new SynonymQuery(new Term(STRING_FIELD_NAME, "bar"),
+                                    new Term(STRING_FIELD_NAME, "bar")), defaultOp))
+                            .add(new BooleanQuery.Builder()
+                                    .add(new BooleanClause(new PrefixQuery(new Term(STRING_FIELD_NAME, "foobar")),
+                                            BooleanClause.Occur.SHOULD))
+                                    .add(new BooleanClause(new PrefixQuery(new Term(STRING_FIELD_NAME, "foobar")),
+                                            BooleanClause.Occur.SHOULD))
+                                    .setDisableCoord(true)
+                                    .build(), defaultOp)
+                            .build(), defaultOp)
+                    .add(new BooleanClause(new SynonymQuery(new Term(STRING_FIELD_NAME, "last"),
+                            new Term(STRING_FIELD_NAME, "last")), defaultOp))
+                    .build();
             assertThat(query, Matchers.equalTo(expectedQuery));
         }
     }
@@ -415,10 +415,10 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
             expectedQuery = new BooleanQuery.Builder()
                     .add(new TermQuery(new Term(STRING_FIELD_NAME, "that")), defaultOp)
                     .add(new BooleanQuery.Builder()
-                         .add(new BooleanQuery.Builder()
-                            .add(new BooleanClause(new TermQuery(new Term(STRING_FIELD_NAME, "guinea")), Occur.MUST))
-                            .add(new BooleanClause(new TermQuery(new Term(STRING_FIELD_NAME, "pig")), Occur.MUST))
-                            .build(), Occur.SHOULD)
+                            .add(new BooleanQuery.Builder()
+                                    .add(new BooleanClause(new TermQuery(new Term(STRING_FIELD_NAME, "guinea")), Occur.MUST))
+                                    .add(new BooleanClause(new TermQuery(new Term(STRING_FIELD_NAME, "pig")), Occur.MUST))
+                                    .build(), Occur.SHOULD)
                             .add(new TermQuery(new Term(STRING_FIELD_NAME, "cavy")), Occur.SHOULD).build(), defaultOp)
                     .add(new TermQuery(new Term(STRING_FIELD_NAME, "smells")), defaultOp)
                     .build();
@@ -430,9 +430,9 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
                     .add(new TermQuery(new Term(STRING_FIELD_NAME, "that")), Occur.MUST)
                     .add(new BooleanQuery.Builder()
                             .add(new BooleanQuery.Builder()
-                                 .add(new TermQuery(new Term(STRING_FIELD_NAME, "guinea")), Occur.MUST)
-                                 .add(new TermQuery(new Term(STRING_FIELD_NAME, "pig")), Occur.MUST)
-                                 .build(), defaultOp)
+                                    .add(new TermQuery(new Term(STRING_FIELD_NAME, "guinea")), Occur.MUST)
+                                    .add(new TermQuery(new Term(STRING_FIELD_NAME, "pig")), Occur.MUST)
+                                    .build(), defaultOp)
                             .add(new TermQuery(new Term(STRING_FIELD_NAME, "cavy")), defaultOp)
                             .build(), Occur.MUST_NOT)
                     .add(new TermQuery(new Term(STRING_FIELD_NAME, "smells")), Occur.MUST)
@@ -443,46 +443,46 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
             // no parent should cause guinea and pig to be treated as separate tokens
             query = queryParser.parse("+that -guinea pig +smells");
             expectedQuery = new BooleanQuery.Builder()
-                .add(new TermQuery(new Term(STRING_FIELD_NAME, "that")), BooleanClause.Occur.MUST)
-                .add(new TermQuery(new Term(STRING_FIELD_NAME, "guinea")), BooleanClause.Occur.MUST_NOT)
-                .add(new TermQuery(new Term(STRING_FIELD_NAME, "pig")), defaultOp)
-                .add(new TermQuery(new Term(STRING_FIELD_NAME, "smells")), BooleanClause.Occur.MUST)
-                .build();
+                    .add(new TermQuery(new Term(STRING_FIELD_NAME, "that")), BooleanClause.Occur.MUST)
+                    .add(new TermQuery(new Term(STRING_FIELD_NAME, "guinea")), BooleanClause.Occur.MUST_NOT)
+                    .add(new TermQuery(new Term(STRING_FIELD_NAME, "pig")), defaultOp)
+                    .add(new TermQuery(new Term(STRING_FIELD_NAME, "smells")), BooleanClause.Occur.MUST)
+                    .build();
 
             assertThat(query, Matchers.equalTo(expectedQuery));
 
             // span query
             query = queryParser.parse("\"that guinea pig smells\"");
             expectedQuery = new BooleanQuery.Builder()
-                .add(new SpanNearQuery.Builder(STRING_FIELD_NAME, true)
-                    .addClause(new SpanTermQuery(new Term(STRING_FIELD_NAME, "that")))
-                    .addClause(new SpanOrQuery(
-                        new SpanNearQuery.Builder(STRING_FIELD_NAME, true)
-                            .addClause(new SpanTermQuery(new Term(STRING_FIELD_NAME, "guinea")))
-                            .addClause(new SpanTermQuery(new Term(STRING_FIELD_NAME, "pig"))).build(),
-                        new SpanTermQuery(new Term(STRING_FIELD_NAME, "cavy"))))
-                    .addClause(new SpanTermQuery(new Term(STRING_FIELD_NAME, "smells")))
-                    .build(), Occur.SHOULD)
-                .setDisableCoord(true)
-                .build();
+                    .add(new SpanNearQuery.Builder(STRING_FIELD_NAME, true)
+                            .addClause(new SpanTermQuery(new Term(STRING_FIELD_NAME, "that")))
+                            .addClause(new SpanOrQuery(
+                                    new SpanNearQuery.Builder(STRING_FIELD_NAME, true)
+                                            .addClause(new SpanTermQuery(new Term(STRING_FIELD_NAME, "guinea")))
+                                            .addClause(new SpanTermQuery(new Term(STRING_FIELD_NAME, "pig"))).build(),
+                                    new SpanTermQuery(new Term(STRING_FIELD_NAME, "cavy"))))
+                            .addClause(new SpanTermQuery(new Term(STRING_FIELD_NAME, "smells")))
+                            .build(), Occur.SHOULD)
+                    .setDisableCoord(true)
+                    .build();
             assertThat(query, Matchers.equalTo(expectedQuery));
 
             // span query with slop
             query = queryParser.parse("\"that guinea pig smells\"~2");
             expectedQuery = new BooleanQuery.Builder()
-                .add(new SpanNearQuery.Builder(STRING_FIELD_NAME, true)
-                    .addClause(new SpanTermQuery(new Term(STRING_FIELD_NAME, "that")))
-                    .addClause(new SpanOrQuery(
-                        new SpanNearQuery.Builder(STRING_FIELD_NAME, true)
-                            .addClause(new SpanTermQuery(new Term(STRING_FIELD_NAME, "guinea")))
-                            .addClause(new SpanTermQuery(new Term(STRING_FIELD_NAME, "pig"))).build(),
-                        new SpanTermQuery(new Term(STRING_FIELD_NAME, "cavy"))))
-                    .addClause(new SpanTermQuery(new Term(STRING_FIELD_NAME, "smells")))
-                    .setSlop(2)
-                    .build(),
-                    Occur.SHOULD)
-                .setDisableCoord(true)
-                .build();
+                    .add(new SpanNearQuery.Builder(STRING_FIELD_NAME, true)
+                                    .addClause(new SpanTermQuery(new Term(STRING_FIELD_NAME, "that")))
+                                    .addClause(new SpanOrQuery(
+                                            new SpanNearQuery.Builder(STRING_FIELD_NAME, true)
+                                                    .addClause(new SpanTermQuery(new Term(STRING_FIELD_NAME, "guinea")))
+                                                    .addClause(new SpanTermQuery(new Term(STRING_FIELD_NAME, "pig"))).build(),
+                                            new SpanTermQuery(new Term(STRING_FIELD_NAME, "cavy"))))
+                                    .addClause(new SpanTermQuery(new Term(STRING_FIELD_NAME, "smells")))
+                                    .setSlop(2)
+                                    .build(),
+                            Occur.SHOULD)
+                    .setDisableCoord(true)
+                    .build();
             assertThat(query, Matchers.equalTo(expectedQuery));
         }
     }
@@ -490,8 +490,8 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
     public void testToQueryRegExpQuery() throws Exception {
         assumeTrue("test runs only when at least a type is registered", getCurrentTypes().length > 0);
         Query query = queryStringQuery("/foo*bar/").defaultField(STRING_FIELD_NAME)
-            .maxDeterminizedStates(5000)
-            .toQuery(createShardContext());
+                .maxDeterminizedStates(5000)
+                .toQuery(createShardContext());
         assertThat(query, instanceOf(RegexpQuery.class));
         RegexpQuery regexpQuery = (RegexpQuery) query;
         assertTrue(regexpQuery.toString().contains("/foo*bar/"));
@@ -572,7 +572,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
         }
 
         Query query = queryStringQuery(queryString.toString()).defaultField(STRING_FIELD_NAME).fuzziness(Fuzziness.AUTO)
-            .toQuery(createShardContext());
+                .toQuery(createShardContext());
         assertThat(query, instanceOf(FuzzyQuery.class));
         FuzzyQuery fuzzyQuery = (FuzzyQuery) query;
         assertEquals(expectedEdits, fuzzyQuery.getMaxEdits());
@@ -653,8 +653,8 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
         float mainBoost = 2.0f / randomIntBetween(3, 20);
         boosts[boosts.length - 1] = mainBoost;
         QueryStringQueryBuilder queryStringQueryBuilder =
-            new QueryStringQueryBuilder(queryString).field(STRING_FIELD_NAME)
-                .minimumShouldMatch("2").boost(mainBoost);
+                new QueryStringQueryBuilder(queryString).field(STRING_FIELD_NAME)
+                        .minimumShouldMatch("2").boost(mainBoost);
         Query query = queryStringQueryBuilder.toQuery(createShardContext());
 
         for (int i = boosts.length - 1; i >= 0; i--) {
@@ -669,16 +669,16 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
         assertThat(booleanQuery.getMinimumNumberShouldMatch(), equalTo(2));
         assertThat(booleanQuery.clauses().get(0).getOccur(), equalTo(BooleanClause.Occur.SHOULD));
         assertThat(booleanQuery.clauses().get(0).getQuery(),
-            equalTo(new TermQuery(new Term(STRING_FIELD_NAME, "foo"))));
+                equalTo(new TermQuery(new Term(STRING_FIELD_NAME, "foo"))));
         assertThat(booleanQuery.clauses().get(1).getOccur(), equalTo(BooleanClause.Occur.SHOULD));
         assertThat(booleanQuery.clauses().get(1).getQuery(),
-            equalTo(new TermQuery(new Term(STRING_FIELD_NAME, "bar"))));
+                equalTo(new TermQuery(new Term(STRING_FIELD_NAME, "bar"))));
     }
 
     public void testToQueryPhraseQueryBoostAndSlop() throws IOException {
         assumeTrue("test runs only when at least a type is registered", getCurrentTypes().length > 0);
         QueryStringQueryBuilder queryStringQueryBuilder =
-            new QueryStringQueryBuilder("\"test phrase\"~2").field(STRING_FIELD_NAME, 5f);
+                new QueryStringQueryBuilder("\"test phrase\"~2").field(STRING_FIELD_NAME, 5f);
         Query query = queryStringQueryBuilder.toQuery(createShardContext());
         assertThat(query, instanceOf(DisjunctionMaxQuery.class));
         DisjunctionMaxQuery disjunctionMaxQuery = (DisjunctionMaxQuery) query;
@@ -697,15 +697,15 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
         // splitOnWhitespace=false
         {
             QueryStringQueryBuilder queryBuilder =
-                new QueryStringQueryBuilder("foo bar")
-                    .field(STRING_FIELD_NAME).field(STRING_FIELD_NAME_2)
-                    .splitOnWhitespace(false);
+                    new QueryStringQueryBuilder("foo bar")
+                            .field(STRING_FIELD_NAME).field(STRING_FIELD_NAME_2)
+                            .splitOnWhitespace(false);
             Query query = queryBuilder.toQuery(createShardContext());
             BooleanQuery bq1 =
-                new BooleanQuery.Builder()
-                    .add(new BooleanClause(new TermQuery(new Term(STRING_FIELD_NAME, "foo")), BooleanClause.Occur.SHOULD))
-                    .add(new BooleanClause(new TermQuery(new Term(STRING_FIELD_NAME, "bar")), BooleanClause.Occur.SHOULD))
-                    .build();
+                    new BooleanQuery.Builder()
+                            .add(new BooleanClause(new TermQuery(new Term(STRING_FIELD_NAME, "foo")), BooleanClause.Occur.SHOULD))
+                            .add(new BooleanClause(new TermQuery(new Term(STRING_FIELD_NAME, "bar")), BooleanClause.Occur.SHOULD))
+                            .build();
             List<Query> disjuncts = new ArrayList<>();
             disjuncts.add(bq1);
             disjuncts.add(new TermQuery(new Term(STRING_FIELD_NAME_2, "foo bar")));
@@ -715,32 +715,32 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
 
         {
             QueryStringQueryBuilder queryBuilder =
-                new QueryStringQueryBuilder("mapped_string:other foo bar")
-                    .field(STRING_FIELD_NAME).field(STRING_FIELD_NAME_2)
-                    .splitOnWhitespace(false);
+                    new QueryStringQueryBuilder("mapped_string:other foo bar")
+                            .field(STRING_FIELD_NAME).field(STRING_FIELD_NAME_2)
+                            .splitOnWhitespace(false);
             Query query = queryBuilder.toQuery(createShardContext());
             BooleanQuery bq1 =
-                new BooleanQuery.Builder()
-                    .add(new BooleanClause(new TermQuery(new Term(STRING_FIELD_NAME, "foo")), BooleanClause.Occur.SHOULD))
-                    .add(new BooleanClause(new TermQuery(new Term(STRING_FIELD_NAME, "bar")), BooleanClause.Occur.SHOULD))
-                    .build();
+                    new BooleanQuery.Builder()
+                            .add(new BooleanClause(new TermQuery(new Term(STRING_FIELD_NAME, "foo")), BooleanClause.Occur.SHOULD))
+                            .add(new BooleanClause(new TermQuery(new Term(STRING_FIELD_NAME, "bar")), BooleanClause.Occur.SHOULD))
+                            .build();
             List<Query> disjuncts = new ArrayList<>();
             disjuncts.add(bq1);
             disjuncts.add(new TermQuery(new Term(STRING_FIELD_NAME_2, "foo bar")));
             DisjunctionMaxQuery disjunctionMaxQuery = new DisjunctionMaxQuery(disjuncts, 0.0f);
             BooleanQuery expectedQuery =
-                new BooleanQuery.Builder()
-                    .add(disjunctionMaxQuery, BooleanClause.Occur.SHOULD)
-                    .add(new TermQuery(new Term(STRING_FIELD_NAME, "other")), BooleanClause.Occur.SHOULD)
-                    .build();
+                    new BooleanQuery.Builder()
+                            .add(disjunctionMaxQuery, BooleanClause.Occur.SHOULD)
+                            .add(new TermQuery(new Term(STRING_FIELD_NAME, "other")), BooleanClause.Occur.SHOULD)
+                            .build();
             assertThat(query, equalTo(expectedQuery));
         }
 
         {
             QueryStringQueryBuilder queryBuilder =
-                new QueryStringQueryBuilder("foo OR bar")
-                    .field(STRING_FIELD_NAME).field(STRING_FIELD_NAME_2)
-                    .splitOnWhitespace(false);
+                    new QueryStringQueryBuilder("foo OR bar")
+                            .field(STRING_FIELD_NAME).field(STRING_FIELD_NAME_2)
+                            .splitOnWhitespace(false);
             Query query = queryBuilder.toQuery(createShardContext());
 
             List<Query> disjuncts1 = new ArrayList<>();
@@ -754,10 +754,10 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
             DisjunctionMaxQuery maxQuery2 = new DisjunctionMaxQuery(disjuncts2, 0.0f);
 
             BooleanQuery expectedQuery =
-                new BooleanQuery.Builder()
-                    .add(new BooleanClause(maxQuery1, BooleanClause.Occur.SHOULD))
-                    .add(new BooleanClause(maxQuery2, BooleanClause.Occur.SHOULD))
-                    .build();
+                    new BooleanQuery.Builder()
+                            .add(new BooleanClause(maxQuery1, BooleanClause.Occur.SHOULD))
+                            .add(new BooleanClause(maxQuery2, BooleanClause.Occur.SHOULD))
+                            .build();
             assertThat(query, equalTo(expectedQuery));
         }
 
@@ -765,21 +765,21 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
         {
             // throws an exception when lenient is set to false
             QueryStringQueryBuilder queryBuilder =
-                new QueryStringQueryBuilder(">10 foo")
-                    .field(INT_FIELD_NAME)
-                    .splitOnWhitespace(false);
+                    new QueryStringQueryBuilder(">10 foo")
+                            .field(INT_FIELD_NAME)
+                            .splitOnWhitespace(false);
             IllegalArgumentException exc =
-                expectThrows(IllegalArgumentException.class, () -> queryBuilder.toQuery(createShardContext()));
+                    expectThrows(IllegalArgumentException.class, () -> queryBuilder.toQuery(createShardContext()));
             assertThat(exc.getMessage(), equalTo("For input string: \"10 foo\""));
         }
 
         {
             // returns an empty boolean query when lenient is set to true
             QueryStringQueryBuilder queryBuilder =
-                new QueryStringQueryBuilder(">10 foo")
-                    .field(INT_FIELD_NAME)
-                    .splitOnWhitespace(false)
-                    .lenient(true);
+                    new QueryStringQueryBuilder(">10 foo")
+                            .field(INT_FIELD_NAME)
+                            .splitOnWhitespace(false)
+                            .lenient(true);
             Query query = queryBuilder.toQuery(createShardContext());
             BooleanQuery bq = new BooleanQuery.Builder().build();
             assertThat(bq, equalTo(query));
@@ -788,9 +788,9 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
         // splitOnWhitespace=true
         {
             QueryStringQueryBuilder queryBuilder =
-                new QueryStringQueryBuilder("foo bar")
-                    .field(STRING_FIELD_NAME).field(STRING_FIELD_NAME_2)
-                    .splitOnWhitespace(true);
+                    new QueryStringQueryBuilder("foo bar")
+                            .field(STRING_FIELD_NAME).field(STRING_FIELD_NAME_2)
+                            .splitOnWhitespace(true);
             Query query = queryBuilder.toQuery(createShardContext());
 
             List<Query> disjuncts1 = new ArrayList<>();
@@ -804,10 +804,10 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
             DisjunctionMaxQuery maxQuery2 = new DisjunctionMaxQuery(disjuncts2, 0.0f);
 
             BooleanQuery expectedQuery =
-                new BooleanQuery.Builder()
-                    .add(new BooleanClause(maxQuery1, BooleanClause.Occur.SHOULD))
-                    .add(new BooleanClause(maxQuery2, BooleanClause.Occur.SHOULD))
-                    .build();
+                    new BooleanQuery.Builder()
+                            .add(new BooleanClause(maxQuery1, BooleanClause.Occur.SHOULD))
+                            .add(new BooleanClause(maxQuery2, BooleanClause.Occur.SHOULD))
+                            .build();
             assertThat(query, equalTo(expectedQuery));
         }
     }
@@ -843,21 +843,21 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
     public void testDisabledFieldNamesField() throws Exception {
         QueryShardContext context = createShardContext();
         context.getMapperService().merge("new_type",
-            new CompressedXContent(
-                PutMappingRequest.buildFromSimplifiedDef("new_type",
-                    "foo", "type=text",
-                    "_field_names", "enabled=false").string()),
-            MapperService.MergeReason.MAPPING_UPDATE, true);
+                new CompressedXContent(
+                        PutMappingRequest.buildFromSimplifiedDef("new_type",
+                                "foo", "type=text",
+                                "_field_names", "enabled=false").string()),
+                MapperService.MergeReason.MAPPING_UPDATE, true);
         QueryStringQueryBuilder queryBuilder = new QueryStringQueryBuilder("foo:*");
         Query query = queryBuilder.toQuery(context);
         Query expected = new WildcardQuery(new Term("foo", "*"));
         assertThat(query, equalTo(expected));
         context.getMapperService().merge("new_type",
-            new CompressedXContent(
-                PutMappingRequest.buildFromSimplifiedDef("new_type",
-                    "foo", "type=text",
-                    "_field_names", "enabled=true").string()),
-            MapperService.MergeReason.MAPPING_UPDATE, true);
+                new CompressedXContent(
+                        PutMappingRequest.buildFromSimplifiedDef("new_type",
+                                "foo", "type=text",
+                                "_field_names", "enabled=true").string()),
+                MapperService.MergeReason.MAPPING_UPDATE, true);
     }
 
 
@@ -865,25 +865,26 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
     public void testFromJson() throws IOException {
         String json =
                 "{\n" +
-                "  \"query_string\" : {\n" +
-                "    \"query\" : \"this AND that OR thus\",\n" +
-                "    \"default_field\" : \"content\",\n" +
-                "    \"fields\" : [ ],\n" +
-                "    \"use_dis_max\" : true,\n" +
-                "    \"tie_breaker\" : 0.0,\n" +
-                "    \"default_operator\" : \"or\",\n" +
-                "    \"auto_generate_phrase_queries\" : false,\n" +
-                "    \"max_determinized_states\" : 10000,\n" +
-                "    \"enable_position_increments\" : true,\n" +
-                "    \"fuzziness\" : \"AUTO\",\n" +
-                "    \"fuzzy_prefix_length\" : 0,\n" +
-                "    \"fuzzy_max_expansions\" : 50,\n" +
-                "    \"phrase_slop\" : 0,\n" +
-                "    \"escape\" : false,\n" +
-                "    \"split_on_whitespace\" : true,\n" +
-                "    \"boost\" : 1.0\n" +
-                "  }\n" +
-                "}";
+                        "  \"query_string\" : {\n" +
+                        "    \"query\" : \"this AND that OR thus\",\n" +
+                        "    \"default_field\" : \"content\",\n" +
+                        "    \"fields\" : [ ],\n" +
+                        "    \"use_dis_max\" : true,\n" +
+                        "    \"tie_breaker\" : 0.0,\n" +
+                        "    \"default_operator\" : \"or\",\n" +
+                        "    \"auto_generate_phrase_queries\" : false,\n" +
+                        "    \"max_determinized_states\" : 10000,\n" +
+                        "    \"enable_position_increments\" : true,\n" +
+                        "    \"fuzziness\" : \"AUTO\",\n" +
+                        "    \"fuzzy_prefix_length\" : 0,\n" +
+                        "    \"fuzzy_max_expansions\" : 50,\n" +
+                        "    \"fuzzy_transpositions\" : true,\n" +
+                        "    \"phrase_slop\" : 0,\n" +
+                        "    \"escape\" : false,\n" +
+                        "    \"split_on_whitespace\" : true,\n" +
+                        "    \"boost\" : 1.0\n" +
+                        "  }\n" +
+                        "}";
 
         QueryStringQueryBuilder parsed = (QueryStringQueryBuilder) parseQuery(json);
         checkGeneratedJson(json, parsed);
@@ -947,12 +948,12 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
     public void testAllFieldsWithFields() throws IOException {
         String json =
                 "{\n" +
-                "  \"query_string\" : {\n" +
-                "    \"query\" : \"this AND that OR thus\",\n" +
-                "    \"fields\" : [\"foo\"],\n" +
-                "    \"all_fields\" : true\n" +
-                "  }\n" +
-                "}";
+                        "  \"query_string\" : {\n" +
+                        "    \"query\" : \"this AND that OR thus\",\n" +
+                        "    \"fields\" : [\"foo\"],\n" +
+                        "    \"all_fields\" : true\n" +
+                        "  }\n" +
+                        "}";
 
         ParsingException e = expectThrows(ParsingException.class, () -> parseQuery(json));
         assertThat(e.getMessage(),
@@ -960,12 +961,12 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
 
         String json2 =
                 "{\n" +
-                "  \"query_string\" : {\n" +
-                "    \"query\" : \"this AND that OR thus\",\n" +
-                "    \"default_field\" : \"foo\",\n" +
-                "    \"all_fields\" : true\n" +
-                "  }\n" +
-                "}";
+                        "  \"query_string\" : {\n" +
+                        "    \"query\" : \"this AND that OR thus\",\n" +
+                        "    \"default_field\" : \"foo\",\n" +
+                        "    \"all_fields\" : true\n" +
+                        "  }\n" +
+                        "}";
 
         e = expectThrows(ParsingException.class, () -> parseQuery(json2));
         assertThat(e.getMessage(),
@@ -977,8 +978,8 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
         builder.autoGeneratePhraseQueries(true);
         builder.splitOnWhitespace(false);
         IllegalArgumentException exc =
-            expectThrows(IllegalArgumentException.class, () -> builder.toQuery(createShardContext()));
+                expectThrows(IllegalArgumentException.class, () -> builder.toQuery(createShardContext()));
         assertEquals(exc.getMessage(),
-            "it is disallowed to disable [split_on_whitespace] if [auto_generate_phrase_queries] is activated");
+                "it is disallowed to disable [split_on_whitespace] if [auto_generate_phrase_queries] is activated");
     }
 }


### PR DESCRIPTION
…eries

# WHAT

Exposed the `fuzzy_transpositions` parameter to the `multi_match` and `query_string` builders such that its value can be set. Also fixed the corresponding tests testing the JSON objects created by the builders.

# WHY 

New addition to improve functionality/flexibility of `multi-match` and `query_string`.

Original issue requires changes in `multi_match`, `query_string`, `simple_query_string` and `fuzzy`. This PR changes `multi_match` and `query_string`. `fuzzy` appears to already have the field `fuzzy_transpositions` and `simple_query_string` requires a deeper understanding of elasticsearch: it is suggested that if this PR is merged into actual elastic/elasticsearch repo that a new issue for `simple_query_string` is created.
