### PR TITLE
Remove `search_analyzer` parameter on 'keyword field' documentation (23609)

### DIFF
--- a/docs/reference/mapping/types/keyword.asciidoc
+++ b/docs/reference/mapping/types/keyword.asciidoc
@@ -91,11 +91,6 @@ The following parameters are accepted by `keyword` fields:
     the <<mapping-source-field,`_source`>> field. Accepts `true` or `false`
     (default).
 
-<<search-analyzer,`search_analyzer`>>::
-
-    The <<analyzer,`analyzer`>> that should be used at search time on
-    <<mapping-index,`analyzed`>> fields. Defaults to the `analyzer` setting.
-
 <<similarity,`similarity`>>::
 
     Which scoring algorithm or _similarity_ should be used. Defaults


### PR DESCRIPTION
`search_analyzer` is not actually supported on keyword field. Updating the docs
for now to remove `search_analyzer` since it currently does not work

Closes Issue 23609