### PR TITLE
Returns index input on create index request (23044)

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/DocWriteResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/DocWriteResponse.java
@@ -59,6 +59,7 @@ public abstract class DocWriteResponse extends ReplicationResponse implements Wr
     private static final String _SEQ_NO = "_seq_no";
     private static final String RESULT = "result";
     private static final String FORCED_REFRESH = "forced_refresh";
+    private static final String _REQUEST = "_request";
 
     /**
      * An enum that represents the the results of CRUD operations, primarily used to communicate the type of
@@ -114,11 +115,13 @@ public abstract class DocWriteResponse extends ReplicationResponse implements Wr
     private ShardId shardId;
     private String id;
     private String type;
+    private String request;
     private long version;
     private long seqNo;
     private boolean forcedRefresh;
-    protected Result result;
 
+    protected Result result;
+    // NORELEASE drop this constructor in favor of the new one below
     public DocWriteResponse(ShardId shardId, String type, String id, long seqNo, long version, Result result) {
         this.shardId = shardId;
         this.type = type;
@@ -128,6 +131,15 @@ public abstract class DocWriteResponse extends ReplicationResponse implements Wr
         this.result = result;
     }
 
+    public DocWriteResponse(ShardId shardId, String type, String id, String request, long seqNo, long version, Result result) {
+        this.shardId = shardId;
+        this.type = type;
+        this.id = id;
+        this.request = request;
+        this.seqNo = seqNo;
+        this.version = version;
+        this.result = result;
+    }
     // needed for deserialization
     protected DocWriteResponse() {
     }
@@ -287,6 +299,10 @@ public abstract class DocWriteResponse extends ReplicationResponse implements Wr
                 .field(_ID, id)
                 .field(_VERSION, version)
                 .field(RESULT, getResult().getLowercase());
+
+        if(request != null){
+          builder.field(_REQUEST, request);
+        }
         if (forcedRefresh) {
             builder.field(FORCED_REFRESH, true);
         }

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexResponse.java
@@ -66,6 +66,6 @@ public class CreateIndexResponse extends AcknowledgedResponse {
     }
 
     public void addCustomFields(XContentBuilder builder) throws IOException {
-        builder.field("shards_acknowledged", isShardsAcked());
+        builder.field("shards_acknowledged", isShardsAcked());  
     }
 }

--- a/core/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
@@ -135,7 +135,9 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
         if (indexResult.hasFailure()) {
             return new BulkItemResultHolder(null, indexResult, bulkItemRequest);
         } else {
-            IndexResponse response = new IndexResponse(primary.shardId(), indexRequest.type(), indexRequest.id(),
+            String requestToReturn = indexRequest.source().utf8ToString();
+            requestToReturn = requestToReturn.replace("\n", "").replace("\"", "");  //Cleans up the request string so the request is more user readable
+            IndexResponse response = new IndexResponse(primary.shardId(), indexRequest.type(), indexRequest.id(), requestToReturn ,
                     indexResult.getSeqNo(), indexResult.getVersion(), indexResult.isCreated());
             return new BulkItemResultHolder(response, indexResult, bulkItemRequest);
         }

--- a/core/src/main/java/org/elasticsearch/action/index/IndexResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/index/IndexResponse.java
@@ -47,6 +47,10 @@ public class IndexResponse extends DocWriteResponse {
         super(shardId, type, id, seqNo, version, created ? Result.CREATED : Result.UPDATED);
     }
 
+    public IndexResponse(ShardId shardId, String type, String id, String input, long seqNo, long version, boolean created) {
+        super(shardId, type, id, input, seqNo, version, created ? Result.CREATED : Result.UPDATED);
+    }
+
     @Override
     public RestStatus status() {
         return result == Result.CREATED ? RestStatus.CREATED : super.status();


### PR DESCRIPTION
@kblincoe 
Important: Issue 23044 "returns index input" is not addressed due to an existing pull request/code for the issue. Instead the JSON request data is returned to the terminal for user confirmation.
**For example the command,**
```json
curl -XPUT 'http://localhost:9200/kimchy/tweet/1?pretty' -H 'Content-Type: application/json' -d '
{
    "user": "kimchy",
    "post_date": "2009-11-15T13:12:00",
    "message": "Trying out Elasticsearch, so far so good?"
}'
```
**now returns,**
```json
{
  "_index" : "kimchy",
  "_type" : "tweet",
  "_id" : "1",
  "_version" : 1,
  "result" : "created",
  "_request" : "{    user: kimchy,    post_date: 2009-11-15T13:12:00,    message: Trying out Elasticsearch, so far so good?}",
  "_shards" : {
    "total" : 2,
    "successful" : 1,
    "failed" : 0
  },
  "_seq_no" : 0,
  "created" : true
}
```
