### PR TITLE
Renamed ICU token filters parameters to snake case (22823)

### DIFF
--- a/docs/plugins/analysis-icu.asciidoc
+++ b/docs/plugins/analysis-icu.asciidoc
@@ -293,7 +293,7 @@ The ICU folding token filter already does Unicode normalization, so there is
 no need to use Normalize character or token filter as well.
 
 Which letters are folded can be controlled by specifying the
-`unicodeSetFilter` parameter, which accepts a
+`unicode_set_filter` parameter, which accepts a
 http://icu-project.org/apiref/icu4j/com/ibm/icu/text/UnicodeSet.html[UnicodeSet].
 
 The following example exempts Swedish characters from folding. It is important
@@ -320,7 +320,7 @@ PUT icu_sample
         "filter": {
           "swedish_folding": {
             "type": "icu_folding",
-            "unicodeSetFilter": "[^åäöÅÄÖ]"
+            "unicode_set_filter": "[^åäöÅÄÖ]"
           }
         }
       }
@@ -432,14 +432,14 @@ Possible values: `shifted` or `non-ignorable`. Sets the alternate handling for
 strength `quaternary` to be either shifted or non-ignorable. Which boils down
 to ignoring punctuation and whitespace.
 
-`caseLevel`::
+`case_level`::
 
 Possible values: `true` or `false` (default). Whether case level sorting is
 required. When strength is set to `primary` this will ignore accent
 differences.
 
 
-`caseFirst`::
+`case_first`::
 
 Possible values: `lower` or `upper`. Useful to control which case is sorted
 first when case is not ignored for strength `tertiary`. The default depends on
@@ -452,11 +452,11 @@ according to their numeric representation. For example the value `egg-9` is
 sorted before the value `egg-21`.
 
 
-`variableTop`::
+`variable_top`::
 
 Single character or contraction. Controls what is variable for `alternate`.
 
-`hiraganaQuaternaryMode`::
+`hiragana_quaternaryMode`::
 
 Possible values: `true` or `false`.  Distinguishing between Katakana and
 Hiragana characters in `quaternary` strength.

--- a/plugins/analysis-icu/src/main/java/org/elasticsearch/index/analysis/IcuCollationTokenFilterFactory.java
+++ b/plugins/analysis-icu/src/main/java/org/elasticsearch/index/analysis/IcuCollationTokenFilterFactory.java
@@ -131,19 +131,19 @@ public class IcuCollationTokenFilterFactory extends AbstractTokenFilterFactory {
             }
         }
 
-        Boolean caseLevel = settings.getAsBooleanLenientForPreEs6Indices(indexSettings.getIndexVersionCreated(), "caseLevel", null, deprecationLogger);
+        Boolean caseLevel = settings.getAsBooleanLenientForPreEs6Indices(indexSettings.getIndexVersionCreated(), "case_level", null, deprecationLogger);
         if (caseLevel != null) {
             rbc.setCaseLevel(caseLevel);
         }
 
-        String caseFirst = settings.get("caseFirst");
+        String caseFirst = settings.get("case_first");
         if (caseFirst != null) {
             if (caseFirst.equalsIgnoreCase("lower")) {
                 rbc.setLowerCaseFirst(true);
             } else if (caseFirst.equalsIgnoreCase("upper")) {
                 rbc.setUpperCaseFirst(true);
             } else {
-                throw new IllegalArgumentException("Invalid caseFirst: " + caseFirst);
+                throw new IllegalArgumentException("Invalid case_first: " + caseFirst);
             }
         }
 
@@ -152,13 +152,13 @@ public class IcuCollationTokenFilterFactory extends AbstractTokenFilterFactory {
             rbc.setNumericCollation(numeric);
         }
 
-        String variableTop = settings.get("variableTop");
+        String variableTop = settings.get("variable_top");
         if (variableTop != null) {
             rbc.setVariableTop(variableTop);
         }
 
         Boolean hiraganaQuaternaryMode = settings
-            .getAsBooleanLenientForPreEs6Indices(indexSettings.getIndexVersionCreated(), "hiraganaQuaternaryMode", null, deprecationLogger);
+            .getAsBooleanLenientForPreEs6Indices(indexSettings.getIndexVersionCreated(), "hiragana_quaternary_mode", null, deprecationLogger);
         if (hiraganaQuaternaryMode != null) {
             rbc.setHiraganaQuaternary(hiraganaQuaternaryMode);
         }

--- a/plugins/analysis-icu/src/main/java/org/elasticsearch/index/analysis/IcuFoldingTokenFilterFactory.java
+++ b/plugins/analysis-icu/src/main/java/org/elasticsearch/index/analysis/IcuFoldingTokenFilterFactory.java
@@ -36,7 +36,7 @@ import org.elasticsearch.index.IndexSettings;
  * Can be filtered to handle certain characters in a specified way (see http://icu-project.org/apiref/icu4j/com/ibm/icu/text/UnicodeSet.html)
  * E.g national chars that should be retained (filter : "[^åäöÅÄÖ]").
  *
- * <p>The <tt>unicodeSetFilter</tt> attribute can be used to provide the UniCodeSet for filtering.
+ * <p>The <tt>unicode_set_filter</tt> attribute can be used to provide the UniCodeSet for filtering.
  *
  * @author kimchy (shay.banon)
  */
@@ -45,7 +45,7 @@ public class IcuFoldingTokenFilterFactory extends AbstractTokenFilterFactory imp
 
     public IcuFoldingTokenFilterFactory(IndexSettings indexSettings, Environment environment, String name, Settings settings) {
         super(indexSettings, name, settings);
-        this.unicodeSetFilter = settings.get("unicodeSetFilter");
+        this.unicodeSetFilter = settings.get("unicode_set_filter");
     }
 
     @Override

--- a/plugins/analysis-icu/src/test/java/org/elasticsearch/index/analysis/SimpleIcuCollationTokenFilterTests.java
+++ b/plugins/analysis-icu/src/test/java/org/elasticsearch/index/analysis/SimpleIcuCollationTokenFilterTests.java
@@ -115,7 +115,7 @@ public class SimpleIcuCollationTokenFilterTests extends ESTestCase {
                 .put("index.analysis.filter.myCollator.language", "en")
                 .put("index.analysis.filter.myCollator.strength", "primary")
                 .put("index.analysis.filter.myCollator.alternate", "shifted")
-                .put("index.analysis.filter.myCollator.variableTop", " ")
+                .put("index.analysis.filter.myCollator.variable_top", " ")
                 .build();
         TestAnalysis analysis = createTestAnalysis(new Index("test", "_na_"), settings, new AnalysisICUPlugin());
 
@@ -150,7 +150,7 @@ public class SimpleIcuCollationTokenFilterTests extends ESTestCase {
                 .put("index.analysis.filter.myCollator.type", "icu_collation")
                 .put("index.analysis.filter.myCollator.language", "en")
                 .put("index.analysis.filter.myCollator.strength", "primary")
-                .put("index.analysis.filter.myCollator.caseLevel", "true")
+                .put("index.analysis.filter.myCollator.case_level", "true")
                 .build();
         TestAnalysis analysis = createTestAnalysis(new Index("test", "_na_"), settings, new AnalysisICUPlugin());
 
@@ -170,7 +170,7 @@ public class SimpleIcuCollationTokenFilterTests extends ESTestCase {
                 .put("index.analysis.filter.myCollator.type", "icu_collation")
                 .put("index.analysis.filter.myCollator.language", "en")
                 .put("index.analysis.filter.myCollator.strength", "tertiary")
-                .put("index.analysis.filter.myCollator.caseFirst", "upper")
+                .put("index.analysis.filter.myCollator.case_first", "upper")
                 .build();
         TestAnalysis analysis = createTestAnalysis(new Index("test", "_na_"), settings, new AnalysisICUPlugin());
 


### PR DESCRIPTION
Parameters in IcuFoldingTokenFilterFactory and IcuCollatedTokenFilterFactory have been modified to use snake case instead of camel case. Tests and documents were also changed to reflect these changes.