### PR TITLE
Fix issue 22870: Documenting the ability to reset index settings with null values in Update Indices Settings doc

### DIFF
--- a/docs/reference/indices/update-settings.asciidoc
+++ b/docs/reference/indices/update-settings.asciidoc
@@ -1,6 +1,7 @@
 [[indices-update-settings]]
 == Update Indices Settings
 
+
 Change specific index level settings in real time.
 
 The REST endpoint is `/_settings` (to update all indices) or
@@ -21,6 +22,20 @@ PUT /twitter/_settings
 
 The list of per-index settings which can be updated dynamically on live
 indices can be found in <<index-modules>>.
+
+Elasticsearch versions 5.x gives the ability to reset index settings by assigning
+a null value to an index property. If you are not on version 5.x please navigate to
+the following link for <<setup-upgrade, setup upgrade>>.
+
+[source, js]
+--------------------------------------------------
+PUT /twitter/_settings
+{
+    "index" : {
+        "number_of_replicas": null
+    }
+}
+--------------------------------------------------
 
 [float]
 [[bulk]]


### PR DESCRIPTION
Elasticsearch 5.x now offers the ability to reset Index settings by submitting a `null` value for the indices. 
This behavior is now documented in the Update Settings Doc. For any users that are not in the latest version of Elasticsearch a link is provided showing how to upgrade Elasticsearch depending on which version the user is currently on. An example is shown in the documentation.