### PR TITLE
Rewrite `range` to `exists` query when bounds are open (22640)

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
+++ b/core/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
@@ -40,6 +40,7 @@ import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.RangeFieldMapper;
+import org.elasticsearch.index.query.ExistsQueryBuilder;
 import org.joda.time.DateTimeZone;
 
 import java.io.IOException;
@@ -464,6 +465,9 @@ public class RangeQueryBuilder extends AbstractQueryBuilder<RangeQueryBuilder> i
 
     @Override
     protected QueryBuilder doRewrite(QueryRewriteContext queryRewriteContext) throws IOException {
+        if (from == null && to == null) {
+          return new ExistsQueryBuilder(fieldName);
+        }
         final MappedFieldType.Relation relation = getRelation(queryRewriteContext);
         switch (relation) {
         case DISJOINT:
@@ -492,7 +496,6 @@ public class RangeQueryBuilder extends AbstractQueryBuilder<RangeQueryBuilder> i
         MappedFieldType mapper = context.fieldMapper(this.fieldName);
         if (mapper != null) {
             if (mapper instanceof DateFieldMapper.DateFieldType) {
-
                 query = ((DateFieldMapper.DateFieldType) mapper).rangeQuery(from, to, includeLower, includeUpper,
                         timeZone, getForceDateParser(), context);
             } else if (mapper instanceof RangeFieldMapper.RangeFieldType && mapper.typeName() == RangeFieldMapper.RangeType.DATE.name) {


### PR DESCRIPTION
Range queries that have both bounds open are costly to execute. The rewrite phase of queries
provides the opportunity to rewrite queries as faster running simpler queries. This PR switches to
an `exists` query if both bounds are open.

The output should be the same for both queries below, but under the hood an exists query is ultimately used

```java
// typical query
GET _search
{
    "query" : {
        "range" : {
            "post_date" : { "from" : "2009-11-15T13:00:00", "to" : "2009-11-15T14:00:00" }
        }
    }
}'
```

```java
// open bounds query
GET _search
{
    "query" : {
        "range" : {
            "post_date" : { }
        }
    }
}'
```

Closes issue 22640