### PR TITLE
Updated document to complete 23435

### DIFF
--- a/docs/plugins/repository-s3.asciidoc
+++ b/docs/plugins/repository-s3.asciidoc
@@ -196,6 +196,9 @@ The following settings are supported:
     Specifies the path within bucket to repository data. Defaults to
     value of `repositories.s3.base_path` or to root directory if not set.
 
+    Please note that although the base path can be started with a "/",
+    this has now been deprecated.
+
 `access_key`::
 
     The access key to use for authentication. Defaults to value of


### PR DESCRIPTION
The documentation has been updated to complete issue 23435.

This update was completed by adding the statement that if the base path starts with "/", that ability has been deprecated.