### PR TITLE
Create new exit code for issue 15295

### DIFF
--- a/core/src/main/java/org/elasticsearch/cli/ExitCodes.java
+++ b/core/src/main/java/org/elasticsearch/cli/ExitCodes.java
@@ -37,7 +37,7 @@ public class ExitCodes {
     public static final int PROTOCOL = 76;       /* remote error in protocol */
     public static final int NOPERM = 77;         /* permission denied */
     public static final int CONFIG = 78;         /* configuration error */
-    public static final int PLUGIN_EXISTS = 79;  /* config error; plugin already exists */
+    public static final int PLUGIN_EXISTS = 79;  /* plugin already exists */
 
     private ExitCodes() { /* no instance, just constants */ }
 }

--- a/core/src/main/java/org/elasticsearch/cli/ExitCodes.java
+++ b/core/src/main/java/org/elasticsearch/cli/ExitCodes.java
@@ -37,6 +37,7 @@ public class ExitCodes {
     public static final int PROTOCOL = 76;       /* remote error in protocol */
     public static final int NOPERM = 77;         /* permission denied */
     public static final int CONFIG = 78;         /* configuration error */
+    public static final int PLUGIN_EXISTS = 79;  /* config error; plugin already exists */
 
     private ExitCodes() { /* no instance, just constants */ }
 }

--- a/core/src/main/java/org/elasticsearch/plugins/InstallPluginCommand.java
+++ b/core/src/main/java/org/elasticsearch/plugins/InstallPluginCommand.java
@@ -427,7 +427,7 @@ class InstallPluginCommand extends EnvironmentAwareCommand {
                 "plugin directory [%s] already exists; if you need to update the plugin, uninstall it first using command 'remove %s'",
                 destination.toAbsolutePath(),
                 info.getName());
-            throw new UserException(ExitCodes.CONFIG, message);
+            throw new UserException(ExitCodes.PLUGIN_EXISTS, message);
         }
 
         terminal.println(VERBOSE, info.toString());


### PR DESCRIPTION
The current build has a number of generic exit codes that do not give much information. This pull request adds a unique exit code for failure of plugin installation (if a user is attempting to install a currently installed plugin).