### PR TITLE
Add check for trailing marker in Msearch requests

### DIFF
--- a/core/build/resources/test/org/elasticsearch/action/search/simple-msearch5.json
+++ b/core/build/resources/test/org/elasticsearch/action/search/simple-msearch5.json
@@ -1,0 +1,2 @@
+{"index":"test", "ignore_unavailable" : true, "expand_wildcards" : "open,closed"}}
+{"query" : {"match_all" :{}}}

--- a/core/src/main/java/org/elasticsearch/rest/action/search/RestMultiSearchAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/search/RestMultiSearchAction.java
@@ -115,6 +115,12 @@ public class RestMultiSearchAction extends BaseRestHandler {
         int from = 0;
         int length = data.length();
         byte marker = xContent.streamSeparator();
+
+        // Check for expected trailing marker
+        if (data.get(data.length() - 1) != marker) {
+            throw new ElasticsearchParseException("Malformed request; requires ending marker");
+        }
+
         while (true) {
             int nextMarker = findNextMarker(marker, from, data, length);
             if (nextMarker == -1) {

--- a/core/src/test/java/org/elasticsearch/action/search/MultiSearchRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/search/MultiSearchRequestTests.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.action.search;
 
+import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.ParseField;
 import org.elasticsearch.common.Strings;
@@ -144,6 +145,15 @@ public class MultiSearchRequestTests extends ESTestCase {
         assertThat(request.requests().get(2).types()[1], equalTo("type1"));
         assertThat(request.requests().get(2).routing(), equalTo("123"));
     }
+
+     public void testMalformedRequest() throws Exception {
+         try {
+             MultiSearchRequest request = parseMultiSearchRequest("/org/elasticsearch/action/search/simple-msearch5.json");
+             fail("Exception not thrown on invalid multisearch request body");
+         } catch (ElasticsearchParseException e) {
+             assertThat(e.getMessage(), equalTo("Malformed request; requires ending marker"));
+         }
+     }
 
     public void testResponseErrorToXContent() throws IOException {
         MultiSearchResponse response = new MultiSearchResponse(


### PR DESCRIPTION
## What

Adds a check that any multisearch request has the appropriate trailing marker for that content type.

Adds a unit test to ensure an exception is thrown if the expected marker is missing.

## Why

Resolves 7601.

7601 identifies that the example request fails if there is no trailing newline, however checking for a trailing newline causes tests to fail.  Reading the code, I am fairly certain that the inconsistency they were experiencing was due to a lack of a trailing marker, which was a newline in their case.

## Who

@kblincoe 
@Helen-Zhao
@azho472