### PR TITLE
Rename timeout param for reindex, update_by_query and delete_by_query rest APIs

### DIFF
--- a/Coordination.md
+++ b/Coordination.md
@@ -29,6 +29,7 @@ Issue number: group name (no links to elasticsearch, just the number - sort by i
 * 22840: Group SmallBit
 * 22845: java ych
 * 22870: Group SmallBit
+* 23044: marathon
 * 23121: The code less traveled
 * 23193: 100
 * 23208: java ych

--- a/client/client-benchmark-noop-api-plugin/src/main/java/org/elasticsearch/plugin/noop/action/bulk/RestNoopBulkAction.java
+++ b/client/client-benchmark-noop-api-plugin/src/main/java/org/elasticsearch/plugin/noop/action/bulk/RestNoopBulkAction.java
@@ -71,7 +71,7 @@ public class RestNoopBulkAction extends BaseRestHandler {
         if (waitForActiveShards != null) {
             bulkRequest.waitForActiveShards(ActiveShardCount.parseString(waitForActiveShards));
         }
-        bulkRequest.timeout(request.paramAsTime("timeout", BulkShardRequest.DEFAULT_TIMEOUT));
+        bulkRequest.timeout(request.paramAsTime("shard_timeout", BulkShardRequest.DEFAULT_TIMEOUT));
         bulkRequest.setRefreshPolicy(request.param("refresh"));
         bulkRequest.add(request.content(), defaultIndex, defaultType, defaultRouting, defaultFields, null, defaultPipeline, null, true,
             request.getXContentType());

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/Request.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/Request.java
@@ -429,7 +429,7 @@ final class Request {
         }
 
         Params withTimeout(TimeValue timeout) {
-            return putParam("timeout", timeout);
+            return putParam("shard_timeout", timeout);
         }
 
         Params withVersion(long version) {

--- a/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestTests.java
+++ b/client/rest-high-level/src/test/java/org/elasticsearch/client/RequestTests.java
@@ -307,9 +307,9 @@ public class RequestTests extends ESTestCase {
         if (randomBoolean()) {
             String timeout = randomTimeValue();
             updateRequest.timeout(timeout);
-            expectedParams.put("timeout", timeout);
+            expectedParams.put("shard_timeout", timeout);
         } else {
-            expectedParams.put("timeout", ReplicationRequest.DEFAULT_TIMEOUT.getStringRep());
+            expectedParams.put("shard_timeout", ReplicationRequest.DEFAULT_TIMEOUT.getStringRep());
         }
         if (randomBoolean()) {
             WriteRequest.RefreshPolicy refreshPolicy = randomFrom(WriteRequest.RefreshPolicy.values());
@@ -399,9 +399,9 @@ public class RequestTests extends ESTestCase {
         if (randomBoolean()) {
             String timeout = randomTimeValue();
             bulkRequest.timeout(timeout);
-            expectedParams.put("timeout", timeout);
+            expectedParams.put("shard_timeout", timeout);
         } else {
-            expectedParams.put("timeout", BulkShardRequest.DEFAULT_TIMEOUT.getStringRep());
+            expectedParams.put("shard_timeout", BulkShardRequest.DEFAULT_TIMEOUT.getStringRep());
         }
 
         if (randomBoolean()) {
@@ -698,9 +698,9 @@ public class RequestTests extends ESTestCase {
         if (randomBoolean()) {
             String timeout = randomTimeValue();
             request.timeout(timeout);
-            expectedParams.put("timeout", timeout);
+            expectedParams.put("shard_timeout", timeout);
         } else {
-            expectedParams.put("timeout", ReplicationRequest.DEFAULT_TIMEOUT.getStringRep());
+            expectedParams.put("shard_timeout", ReplicationRequest.DEFAULT_TIMEOUT.getStringRep());
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/action/bulk/byscroll/AbstractAsyncBulkByScrollAction.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/byscroll/AbstractAsyncBulkByScrollAction.java
@@ -312,7 +312,7 @@ public abstract class AbstractAsyncBulkByScrollAction<Request extends AbstractBu
             startNextScroll(thisBatchStartTime, 0);
             return;
         }
-        request.timeout(mainRequest.getTimeout());
+        request.timeout(mainRequest.getShardTimeout());
         request.waitForActiveShards(mainRequest.getWaitForActiveShards());
         if (logger.isDebugEnabled()) {
             logger.debug("sending [{}] entry, [{}] bulk request", request.requests().size(),

--- a/core/src/main/java/org/elasticsearch/action/bulk/byscroll/AbstractBulkByScrollRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/byscroll/AbstractBulkByScrollRequest.java
@@ -69,7 +69,7 @@ public abstract class AbstractBulkByScrollRequest<Self extends AbstractBulkByScr
     /**
      * Timeout to wait for the shards on to be available for each bulk request?
      */
-    private TimeValue timeout = ReplicationRequest.DEFAULT_TIMEOUT;
+    private TimeValue shardTimeout = ReplicationRequest.DEFAULT_TIMEOUT;
 
     /**
      * The number of shard copies that must be active before proceeding with the write.
@@ -231,15 +231,15 @@ public abstract class AbstractBulkByScrollRequest<Self extends AbstractBulkByScr
     /**
      * Timeout to wait for the shards on to be available for each bulk request?
      */
-    public TimeValue getTimeout() {
-        return timeout;
+    public TimeValue getShardTimeout() {
+        return shardTimeout;
     }
 
     /**
      * Timeout to wait for the shards on to be available for each bulk request?
      */
-    public Self setTimeout(TimeValue timeout) {
-        this.timeout = timeout;
+    public Self setShardTimeout(TimeValue shardTimeout) {
+        this.shardTimeout = shardTimeout;
         return self();
     }
 
@@ -361,7 +361,7 @@ public abstract class AbstractBulkByScrollRequest<Self extends AbstractBulkByScr
      * Setup a clone of this request with the information needed to process a slice of it.
      */
     protected Self doForSlice(Self request, TaskId slicingTask) {
-        request.setAbortOnVersionConflict(abortOnVersionConflict).setRefresh(refresh).setTimeout(timeout)
+        request.setAbortOnVersionConflict(abortOnVersionConflict).setRefresh(refresh).setShardTimeout(shardTimeout)
                 .setWaitForActiveShards(activeShardCount).setRetryBackoffInitialTime(retryBackoffInitialTime).setMaxRetries(maxRetries)
                 // Parent task will store result
                 .setShouldStoreResult(false)
@@ -397,7 +397,7 @@ public abstract class AbstractBulkByScrollRequest<Self extends AbstractBulkByScr
         abortOnVersionConflict = in.readBoolean();
         size = in.readVInt();
         refresh = in.readBoolean();
-        timeout = new TimeValue(in);
+        shardTimeout = new TimeValue(in);
         activeShardCount = ActiveShardCount.readFrom(in);
         retryBackoffInitialTime = new TimeValue(in);
         maxRetries = in.readVInt();
@@ -416,7 +416,7 @@ public abstract class AbstractBulkByScrollRequest<Self extends AbstractBulkByScr
         out.writeBoolean(abortOnVersionConflict);
         out.writeVInt(size);
         out.writeBoolean(refresh);
-        timeout.writeTo(out);
+        shardTimeout.writeTo(out);
         activeShardCount.writeTo(out);
         retryBackoffInitialTime.writeTo(out);
         out.writeVInt(maxRetries);

--- a/core/src/main/java/org/elasticsearch/action/bulk/byscroll/AbstractBulkByScrollRequestBuilder.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/byscroll/AbstractBulkByScrollRequestBuilder.java
@@ -94,7 +94,7 @@ public abstract class AbstractBulkByScrollRequestBuilder<
      * Timeout to wait for the shards on to be available for each bulk request.
      */
     public Self timeout(TimeValue timeout) {
-        request.setTimeout(timeout);
+        request.setShardTimeout(timeout);
         return self();
     }
 

--- a/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestRolloverIndexAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/admin/indices/RestRolloverIndexAction.java
@@ -42,7 +42,7 @@ public class RestRolloverIndexAction extends BaseRestHandler {
         RolloverRequest rolloverIndexRequest = new RolloverRequest(request.param("index"), request.param("new_index"));
         request.applyContentParser(parser -> RolloverRequest.PARSER.parse(parser, rolloverIndexRequest, null));
         rolloverIndexRequest.dryRun(request.paramAsBoolean("dry_run", false));
-        rolloverIndexRequest.timeout(request.paramAsTime("timeout", rolloverIndexRequest.timeout()));
+        rolloverIndexRequest.timeout(request.paramAsTime("shard_timeout", rolloverIndexRequest.timeout()));
         rolloverIndexRequest.masterNodeTimeout(request.paramAsTime("master_timeout", rolloverIndexRequest.masterNodeTimeout()));
         rolloverIndexRequest.setWaitForActiveShards(ActiveShardCount.parseString(request.param("wait_for_active_shards")));
         return channel -> client.admin().indices().rolloverIndex(rolloverIndexRequest, new RestToXContentListener<>(channel));

--- a/core/src/main/java/org/elasticsearch/rest/action/document/RestBulkAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/document/RestBulkAction.java
@@ -84,7 +84,7 @@ public class RestBulkAction extends BaseRestHandler {
         if (waitForActiveShards != null) {
             bulkRequest.waitForActiveShards(ActiveShardCount.parseString(waitForActiveShards));
         }
-        bulkRequest.timeout(request.paramAsTime("timeout", BulkShardRequest.DEFAULT_TIMEOUT));
+        bulkRequest.timeout(request.paramAsTime("shard_timeout", BulkShardRequest.DEFAULT_TIMEOUT));
         bulkRequest.setRefreshPolicy(request.param("refresh"));
         bulkRequest.add(request.content(), defaultIndex, defaultType, defaultRouting, defaultFields,
             defaultFetchSourceContext, defaultPipeline, null, allowExplicitIndex, request.getXContentType());

--- a/core/src/main/java/org/elasticsearch/rest/action/document/RestDeleteAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/document/RestDeleteAction.java
@@ -45,7 +45,7 @@ public class RestDeleteAction extends BaseRestHandler {
         DeleteRequest deleteRequest = new DeleteRequest(request.param("index"), request.param("type"), request.param("id"));
         deleteRequest.routing(request.param("routing"));
         deleteRequest.parent(request.param("parent"));
-        deleteRequest.timeout(request.paramAsTime("timeout", DeleteRequest.DEFAULT_TIMEOUT));
+        deleteRequest.timeout(request.paramAsTime("shard_timeout", DeleteRequest.DEFAULT_TIMEOUT));
         deleteRequest.setRefreshPolicy(request.param("refresh"));
         deleteRequest.version(RestActions.parseVersion(request));
         deleteRequest.versionType(VersionType.fromString(request.param("version_type"), deleteRequest.versionType()));

--- a/core/src/main/java/org/elasticsearch/rest/action/document/RestIndexAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/document/RestIndexAction.java
@@ -65,7 +65,7 @@ public class RestIndexAction extends BaseRestHandler {
         indexRequest.parent(request.param("parent"));
         indexRequest.setPipeline(request.param("pipeline"));
         indexRequest.source(request.content(), request.getXContentType());
-        indexRequest.timeout(request.paramAsTime("timeout", IndexRequest.DEFAULT_TIMEOUT));
+        indexRequest.timeout(request.paramAsTime("shard_timeout", IndexRequest.DEFAULT_TIMEOUT));
         indexRequest.setRefreshPolicy(request.param("refresh"));
         indexRequest.version(RestActions.parseVersion(request));
         indexRequest.versionType(VersionType.fromString(request.param("version_type"), indexRequest.versionType()));

--- a/core/src/main/java/org/elasticsearch/rest/action/document/RestUpdateAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/document/RestUpdateAction.java
@@ -53,7 +53,7 @@ public class RestUpdateAction extends BaseRestHandler {
         UpdateRequest updateRequest = new UpdateRequest(request.param("index"), request.param("type"), request.param("id"));
         updateRequest.routing(request.param("routing"));
         updateRequest.parent(request.param("parent"));
-        updateRequest.timeout(request.paramAsTime("timeout", updateRequest.timeout()));
+        updateRequest.timeout(request.paramAsTime("shard_timeout", updateRequest.timeout()));
         updateRequest.setRefreshPolicy(request.param("refresh"));
         String waitForActiveShards = request.param("wait_for_active_shards");
         if (waitForActiveShards != null) {

--- a/docs/reference/docs/index_.asciidoc
+++ b/docs/reference/docs/index_.asciidoc
@@ -394,13 +394,13 @@ available when the index operation is executed. Some reasons for this
 might be that the primary shard is currently recovering from a gateway
 or undergoing relocation. By default, the index operation will wait on
 the primary shard to become available for up to 1 minute before failing
-and responding with an error. The `timeout` parameter can be used to
+and responding with an error. The `shard_timeout` parameter can be used to
 explicitly specify how long it waits. Here is an example of setting it
 to 5 minutes:
 
 [source,js]
 --------------------------------------------------
-PUT twitter/tweet/1?timeout=5m
+PUT twitter/tweet/1?shard_timeout=5m
 {
     "user" : "kimchy",
     "post_date" : "2009-11-15T14:12:12",

--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -511,7 +511,7 @@ POST _reindex
 === URL Parameters
 
 In addition to the standard parameters like `pretty`, the Reindex API also
-supports `refresh`, `wait_for_completion`, `wait_for_active_shards`, `timeout`, and
+supports `refresh`, `wait_for_completion`, `wait_for_active_shards`, `shard_timeout`, and
 `requests_per_second`.
 
 Sending the `refresh` url parameter will cause all indexes to which the request
@@ -528,7 +528,7 @@ Elasticsearch can reclaim the space it uses.
 
 `wait_for_active_shards` controls how many copies of a shard must be active
 before proceeding with the reindexing. See <<index-wait-for-active-shards,here>>
-for details. `timeout` controls how long each write request waits for unavailable
+for details. `shard_timeout` controls how long each write request waits for unavailable
 shards to become available. Both work exactly how they work in the
 <<docs-bulk,Bulk API>>.
 

--- a/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractBaseReindexRestHandler.java
+++ b/modules/reindex/src/main/java/org/elasticsearch/index/reindex/AbstractBaseReindexRestHandler.java
@@ -92,7 +92,7 @@ public abstract class AbstractBaseReindexRestHandler<
         assert request != null : "Request should not be null";
 
         request.setRefresh(restRequest.paramAsBoolean("refresh", request.isRefresh()));
-        request.setTimeout(restRequest.paramAsTime("timeout", request.getTimeout()));
+        request.setShardTimeout(restRequest.paramAsTime("shard_timeout", request.getShardTimeout()));
         request.setSlices(restRequest.paramAsInt("slices", request.getSlices()));
 
         String waitForActiveShards = restRequest.param("wait_for_active_shards");

--- a/modules/reindex/src/test/java/org/elasticsearch/index/reindex/RoundTripTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/index/reindex/RoundTripTests.java
@@ -137,7 +137,7 @@ public class RoundTripTests extends ESTestCase {
         request.setSize(random().nextBoolean() ? between(1, Integer.MAX_VALUE) : -1);
         request.setAbortOnVersionConflict(random().nextBoolean());
         request.setRefresh(rarely());
-        request.setTimeout(TimeValue.parseTimeValue(randomTimeValue(), null, "test"));
+        request.setShardTimeout(TimeValue.parseTimeValue(randomTimeValue(), null, "test"));
         request.setWaitForActiveShards(randomIntBetween(0, 10));
         request.setRequestsPerSecond(between(0, Integer.MAX_VALUE));
         request.setSlices(between(1, Integer.MAX_VALUE));
@@ -183,7 +183,7 @@ public class RoundTripTests extends ESTestCase {
         assertEquals(request.getSearchRequest().source().size(), tripped.getSearchRequest().source().size());
         assertEquals(request.isAbortOnVersionConflict(), tripped.isAbortOnVersionConflict());
         assertEquals(request.isRefresh(), tripped.isRefresh());
-        assertEquals(request.getTimeout(), tripped.getTimeout());
+        assertEquals(request.getShardTimeout(), tripped.getShardTimeout());
         assertEquals(request.getWaitForActiveShards(), tripped.getWaitForActiveShards());
         assertEquals(request.getRetryBackoffInitialTime(), tripped.getRetryBackoffInitialTime());
         assertEquals(request.getMaxRetries(), tripped.getMaxRetries());

--- a/modules/reindex/src/test/resources/rest-api-spec/test/delete_by_query/50_wait_for_active_shards.yaml
+++ b/modules/reindex/src/test/resources/rest-api-spec/test/delete_by_query/50_wait_for_active_shards.yaml
@@ -19,7 +19,7 @@
       catch: unavailable
       delete_by_query:
         index: test
-        timeout: 1s
+        shard_timeout: 1s
         wait_for_active_shards: 4
         body:
           query:

--- a/modules/reindex/src/test/resources/rest-api-spec/test/reindex/60_wait_for_active_shards.yaml
+++ b/modules/reindex/src/test/resources/rest-api-spec/test/reindex/60_wait_for_active_shards.yaml
@@ -18,7 +18,7 @@
   - do:
       catch: unavailable
       reindex:
-        timeout: 1s
+        shard_timeout: 1s
         wait_for_active_shards: 4
         body:
           source:

--- a/modules/reindex/src/test/resources/rest-api-spec/test/update_by_query/50_consistency.yaml
+++ b/modules/reindex/src/test/resources/rest-api-spec/test/update_by_query/50_consistency.yaml
@@ -20,7 +20,7 @@
       update_by_query:
         index: test
         wait_for_active_shards: 4
-        timeout: 1s
+        shard_timeout: 1s
   - match:
       failures.0.cause.reason: /Not.enough.active.copies.to.meet.shard.count.of.\[4\].\(have.1,.needed.4\)..Timeout\:.\[1s\],.request:.+/
 

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/delete_by_query.json
@@ -130,7 +130,7 @@
           "type" : "boolean",
           "description" : "Should the effected indexes be refreshed?"
         },
-        "timeout": {
+        "shard_timeout": {
           "type" : "time",
           "default": "1m",
           "description" : "Time each individual bulk request should wait for shards that are unavailable."

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/reindex.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/reindex.json
@@ -11,7 +11,7 @@
           "type" : "boolean",
           "description" : "Should the effected indexes be refreshed?"
         },
-        "timeout": {
+        "shard_timeout": {
           "type" : "time",
           "default": "1m",
           "description" : "Time each individual bulk request should wait for shards that are unavailable."

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/update_by_query.json
@@ -138,7 +138,7 @@
           "type" : "boolean",
           "description" : "Should the effected indexes be refreshed?"
         },
-        "timeout": {
+        "shard_timeout": {
           "type" : "time",
           "default": "1m",
           "description" : "Time each individual bulk request should wait for shards that are unavailable."

--- a/test/framework/src/main/java/org/elasticsearch/action/bulk/byscroll/AbstractBulkByScrollRequestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/action/bulk/byscroll/AbstractBulkByScrollRequestTestCase.java
@@ -35,7 +35,7 @@ public abstract class AbstractBulkByScrollRequestTestCase<R extends AbstractBulk
         R original = newRequest();
         original.setAbortOnVersionConflict(randomBoolean());
         original.setRefresh(randomBoolean());
-        original.setTimeout(parseTimeValue(randomPositiveTimeValue(), "timeout"));
+        original.setShardTimeout(parseTimeValue(randomPositiveTimeValue(), "shard_timeout"));
         original.setWaitForActiveShards(
                 randomFrom(ActiveShardCount.ALL, ActiveShardCount.NONE, ActiveShardCount.ONE, ActiveShardCount.DEFAULT));
         original.setRetryBackoffInitialTime(parseTimeValue(randomPositiveTimeValue(), "retry_backoff_initial_time"));
@@ -50,7 +50,7 @@ public abstract class AbstractBulkByScrollRequestTestCase<R extends AbstractBulk
         R forSliced = original.forSlice(slicingTask, sliceRequest);
         assertEquals(original.isAbortOnVersionConflict(), forSliced.isAbortOnVersionConflict());
         assertEquals(original.isRefresh(), forSliced.isRefresh());
-        assertEquals(original.getTimeout(), forSliced.getTimeout());
+        assertEquals(original.getShardTimeout(), forSliced.getShardTimeout());
         assertEquals(original.getWaitForActiveShards(), forSliced.getWaitForActiveShards());
         assertEquals(original.getRetryBackoffInitialTime(), forSliced.getRetryBackoffInitialTime());
         assertEquals(original.getMaxRetries(), forSliced.getMaxRetries());


### PR DESCRIPTION
- Change `timeout` param to `shard_timeout` for the following APIs: `reindex`, `update_by_query` and `delete_by_query`

- Update references of the param throughout code and test cases to use the new param `shard_timeout`

Resolves issue 17620