### PR TITLE
Reject request with both upsert and a version

### DIFF
--- a/core/src/main/java/org/elasticsearch/rest/action/document/RestUpdateAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/document/RestUpdateAction.java
@@ -83,7 +83,7 @@ public class RestUpdateAction extends BaseRestHandler {
             IndexRequest upsertRequest = updateRequest.upsertRequest();
             if (upsertRequest != null) {
                 if (request.hasParam("version")) {
-                    throw new IllegalArgumentException("Requests with both upsert and a version are rejected.");
+                    throw new IllegalArgumentException("An upsert request cannot specify version.");
                 }
                 upsertRequest.routing(request.param("routing"));
                 upsertRequest.parent(request.param("parent"));

--- a/core/src/main/java/org/elasticsearch/rest/action/document/RestUpdateAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/document/RestUpdateAction.java
@@ -82,6 +82,9 @@ public class RestUpdateAction extends BaseRestHandler {
             updateRequest.fromXContent(parser);
             IndexRequest upsertRequest = updateRequest.upsertRequest();
             if (upsertRequest != null) {
+                if (request.hasParam("version")) {
+                    throw new IllegalArgumentException("Requests with both upsert and a version are rejected.");
+                }
                 upsertRequest.routing(request.param("routing"));
                 upsertRequest.parent(request.param("parent"));
                 upsertRequest.version(RestActions.parseVersion(request));


### PR DESCRIPTION
Fixes 16671.
Added a check that throws an error if the request has both upsert and a version.
