### PR TITLE
Fix #10441

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/termvectors/TermVectorsResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/termvectors/TermVectorsResponse.java
@@ -36,14 +36,18 @@ import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.ToXContentObject;
 import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentFactory;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.search.dfs.AggregatedDfs;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Set;
 
 public class TermVectorsResponse extends ActionResponse implements ToXContentObject {
@@ -167,6 +171,18 @@ public class TermVectorsResponse extends ActionResponse implements ToXContentObj
                 }
             };
         }
+    }
+
+    public Map<String, Object> sourceAsMap() throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        this.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        return XContentHelper.convertToMap(builder.bytes(), false, null).v2();
+    }
+
+    public String sourceAsString() throws IOException {
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        this.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        return builder.string();
     }
 
     @Override

--- a/core/src/test/java/org/elasticsearch/action/termvectors/TermVectorsUnitTests.java
+++ b/core/src/test/java/org/elasticsearch/action/termvectors/TermVectorsUnitTests.java
@@ -64,6 +64,8 @@ import java.util.Base64;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
 
@@ -101,6 +103,30 @@ public class TermVectorsUnitTests extends ESTestCase {
         inResponse.readFrom(esBuffer);
         assertTrue(inResponse.isExists());
 
+    }
+
+    private void testSourceAsString() throws IOException {
+        TermVectorsResponse testResponse = new TermVectorsResponse("c", "d", "e");
+        String vectorString = testResponse.sourceAsString();
+        String expectedString = "{\"_index\":\"c\",\"_type\":\"d\",\"_id\":\"e\",\"_version\":0,\"found\":false,\"took\":0}";
+        assertTrue(expectedString == vectorString);
+    }
+
+    private void testSourceAsMap() throws IOException {
+        TermVectorsResponse testResponse = new TermVectorsResponse("c", "d", "e");
+        Map<String,Object> expectedMap = new HashMap<String,Object>(){{
+            put("took", "0");
+            put("found", "false");
+            put("_index", "c");
+            put("_type", "d");
+            put("_id", "e");
+            put("_version", "0");
+        }};
+        Map<String,Object> actualMap = testResponse.sourceAsMap();
+        expectedMap.forEach((key, value) -> {
+            assertTrue(actualMap.containsKey(key));
+            assertTrue(actualMap.containsValue(value));
+        });
     }
 
     private void writeEmptyTermVector(TermVectorsResponse outResponse) throws IOException {


### PR DESCRIPTION
Added sourceAsMap() and sourceAsString() to TermVectorsResponse. These
methods provide extra utility for converting term vectors to a Map or
String format.