### PR TITLE
Added took time output for index requests to DocWriteResponse

### DIFF
--- a/client/client-benchmark-noop-api-plugin/src/main/java/org/elasticsearch/plugin/noop/action/bulk/RestNoopBulkAction.java
+++ b/client/client-benchmark-noop-api-plugin/src/main/java/org/elasticsearch/plugin/noop/action/bulk/RestNoopBulkAction.java
@@ -85,7 +85,7 @@ public class RestNoopBulkAction extends BaseRestHandler {
 
     private static class BulkRestBuilderListener extends RestBuilderListener<BulkRequest> {
         private final BulkItemResponse ITEM_RESPONSE = new BulkItemResponse(1, DocWriteRequest.OpType.UPDATE,
-            new UpdateResponse(new ShardId("mock", "", 1), "mock_type", "1", 1L, DocWriteResponse.Result.CREATED));
+            new UpdateResponse(new ShardId("mock", "", 1), "mock_type", "1", 1L, DocWriteResponse.Result.CREATED, 0L));
 
         private final RestRequest request;
 

--- a/client/client-benchmark-noop-api-plugin/src/main/java/org/elasticsearch/plugin/noop/action/bulk/RestNoopBulkAction.java
+++ b/client/client-benchmark-noop-api-plugin/src/main/java/org/elasticsearch/plugin/noop/action/bulk/RestNoopBulkAction.java
@@ -29,6 +29,7 @@ import org.elasticsearch.client.Requests;
 import org.elasticsearch.client.node.NodeClient;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.rest.BaseRestHandler;
@@ -85,7 +86,8 @@ public class RestNoopBulkAction extends BaseRestHandler {
 
     private static class BulkRestBuilderListener extends RestBuilderListener<BulkRequest> {
         private final BulkItemResponse ITEM_RESPONSE = new BulkItemResponse(1, DocWriteRequest.OpType.UPDATE,
-            new UpdateResponse(new ShardId("mock", "", 1), "mock_type", "1", 1L, DocWriteResponse.Result.CREATED, 0L));
+            new UpdateResponse(new ShardId("mock", "", 1), "mock_type", "1", 1L,
+                DocWriteResponse.Result.CREATED, new TimeValue(1L)));
 
         private final RestRequest request;
 

--- a/client/client-benchmark-noop-api-plugin/src/main/java/org/elasticsearch/plugin/noop/action/bulk/RestNoopBulkAction.java
+++ b/client/client-benchmark-noop-api-plugin/src/main/java/org/elasticsearch/plugin/noop/action/bulk/RestNoopBulkAction.java
@@ -87,7 +87,7 @@ public class RestNoopBulkAction extends BaseRestHandler {
     private static class BulkRestBuilderListener extends RestBuilderListener<BulkRequest> {
         private final BulkItemResponse ITEM_RESPONSE = new BulkItemResponse(1, DocWriteRequest.OpType.UPDATE,
             new UpdateResponse(new ShardId("mock", "", 1), "mock_type", "1", 1L,
-                DocWriteResponse.Result.CREATED, new TimeValue(1L)));
+                DocWriteResponse.Result.CREATED, TimeValue.timeValueMillis(1L)));
 
         private final RestRequest request;
 

--- a/client/client-benchmark-noop-api-plugin/src/main/java/org/elasticsearch/plugin/noop/action/bulk/TransportNoopBulkAction.java
+++ b/client/client-benchmark-noop-api-plugin/src/main/java/org/elasticsearch/plugin/noop/action/bulk/TransportNoopBulkAction.java
@@ -36,7 +36,7 @@ import org.elasticsearch.transport.TransportService;
 
 public class TransportNoopBulkAction extends HandledTransportAction<BulkRequest, BulkResponse> {
     private static final BulkItemResponse ITEM_RESPONSE = new BulkItemResponse(1, DocWriteRequest.OpType.UPDATE,
-        new UpdateResponse(new ShardId("mock", "", 1), "mock_type", "1", 1L, DocWriteResponse.Result.CREATED));
+        new UpdateResponse(new ShardId("mock", "", 1), "mock_type", "1", 1L, DocWriteResponse.Result.CREATED, 0L));
 
     @Inject
     public TransportNoopBulkAction(Settings settings, ThreadPool threadPool, TransportService transportService,

--- a/client/client-benchmark-noop-api-plugin/src/main/java/org/elasticsearch/plugin/noop/action/bulk/TransportNoopBulkAction.java
+++ b/client/client-benchmark-noop-api-plugin/src/main/java/org/elasticsearch/plugin/noop/action/bulk/TransportNoopBulkAction.java
@@ -38,7 +38,7 @@ import org.elasticsearch.transport.TransportService;
 public class TransportNoopBulkAction extends HandledTransportAction<BulkRequest, BulkResponse> {
     private static final BulkItemResponse ITEM_RESPONSE = new BulkItemResponse(1, DocWriteRequest.OpType.UPDATE,
         new UpdateResponse(new ShardId("mock", "", 1), "mock_type", "1", 1L, DocWriteResponse.Result.CREATED,
-            new TimeValue(1L)));
+            TimeValue.timeValueMillis(1L)));
 
     @Inject
     public TransportNoopBulkAction(Settings settings, ThreadPool threadPool, TransportService transportService,

--- a/client/client-benchmark-noop-api-plugin/src/main/java/org/elasticsearch/plugin/noop/action/bulk/TransportNoopBulkAction.java
+++ b/client/client-benchmark-noop-api-plugin/src/main/java/org/elasticsearch/plugin/noop/action/bulk/TransportNoopBulkAction.java
@@ -30,13 +30,15 @@ import org.elasticsearch.action.update.UpdateResponse;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
 public class TransportNoopBulkAction extends HandledTransportAction<BulkRequest, BulkResponse> {
     private static final BulkItemResponse ITEM_RESPONSE = new BulkItemResponse(1, DocWriteRequest.OpType.UPDATE,
-        new UpdateResponse(new ShardId("mock", "", 1), "mock_type", "1", 1L, DocWriteResponse.Result.CREATED, 0L));
+        new UpdateResponse(new ShardId("mock", "", 1), "mock_type", "1", 1L, DocWriteResponse.Result.CREATED,
+            new TimeValue(1L)));
 
     @Inject
     public TransportNoopBulkAction(Settings settings, ThreadPool threadPool, TransportService transportService,

--- a/core/src/main/java/org/elasticsearch/action/DocWriteResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/DocWriteResponse.java
@@ -271,7 +271,7 @@ public abstract class DocWriteResponse extends ReplicationResponse implements Wr
         if (in.getVersion().onOrAfter(Version.V_6_0_0_alpha1_UNRELEASED)) {
             took = new TimeValue(in);
         } else {
-            took = new TimeValue(-1L);
+            took = TimeValue.timeValueMillis(-1L);
         }
     }
 
@@ -354,7 +354,7 @@ public abstract class DocWriteResponse extends ReplicationResponse implements Wr
                 }
             } else if (TOOK.equals(currentFieldName)) {
                 // parser.longValue() returns took time in milliseconds
-                context.setTook(new TimeValue(parser.longValue()));
+                context.setTook(TimeValue.timeValueMillis(parser.longValue()));
             } else if (FORCED_REFRESH.equals(currentFieldName)) {
                 context.setForcedRefresh(parser.booleanValue());
             } else if (_SEQ_NO.equals(currentFieldName)) {

--- a/core/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
+++ b/core/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
@@ -136,7 +136,7 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
             return new BulkItemResultHolder(null, indexResult, bulkItemRequest);
         } else {
             IndexResponse response = new IndexResponse(primary.shardId(), indexRequest.type(), indexRequest.id(),
-                    indexResult.getSeqNo(), indexResult.getVersion(), indexResult.isCreated());
+                    indexResult.getSeqNo(), indexResult.getVersion(), indexResult.isCreated(), indexResult.getTook());
             return new BulkItemResultHolder(response, indexResult, bulkItemRequest);
         }
     }
@@ -149,7 +149,7 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
             return new BulkItemResultHolder(null, deleteResult, bulkItemRequest);
         } else {
             DeleteResponse response = new DeleteResponse(primary.shardId(), deleteRequest.type(), deleteRequest.id(),
-                    deleteResult.getSeqNo(), deleteResult.getVersion(), deleteResult.isFound());
+                    deleteResult.getSeqNo(), deleteResult.getVersion(), deleteResult.isFound(), deleteResult.getTook());
             return new BulkItemResultHolder(response, deleteResult, bulkItemRequest);
         }
     }
@@ -301,11 +301,12 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
                         IndexRequest updateIndexRequest = translate.action();
                         final IndexResponse indexResponse = new IndexResponse(primary.shardId(),
                             updateIndexRequest.type(), updateIndexRequest.id(), updateOperationResult.getSeqNo(),
-                            updateOperationResult.getVersion(), ((Engine.IndexResult) updateOperationResult).isCreated());
+                            updateOperationResult.getVersion(), ((Engine.IndexResult) updateOperationResult).isCreated(),
+                            updateOperationResult.getTook());
                         BytesReference indexSourceAsBytes = updateIndexRequest.source();
                         updateResponse = new UpdateResponse(indexResponse.getShardInfo(),
                             indexResponse.getShardId(), indexResponse.getType(), indexResponse.getId(), indexResponse.getSeqNo(),
-                            indexResponse.getVersion(), indexResponse.getResult());
+                            indexResponse.getVersion(), indexResponse.getResult(), indexResponse.getTookInNanos());
                         if ((updateRequest.fetchSource() != null && updateRequest.fetchSource().fetchSource()) ||
                             (updateRequest.fields() != null && updateRequest.fields().length > 0)) {
                             Tuple<XContentType, Map<String, Object>> sourceAndContent =
@@ -320,10 +321,11 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
                         DeleteRequest updateDeleteRequest = translate.action();
                         DeleteResponse deleteResponse = new DeleteResponse(primary.shardId(),
                             updateDeleteRequest.type(), updateDeleteRequest.id(), updateOperationResult.getSeqNo(),
-                            updateOperationResult.getVersion(), ((Engine.DeleteResult) updateOperationResult).isFound());
+                            updateOperationResult.getVersion(), ((Engine.DeleteResult) updateOperationResult).isFound(),
+                            updateOperationResult.getTook());
                         updateResponse = new UpdateResponse(deleteResponse.getShardInfo(),
                             deleteResponse.getShardId(), deleteResponse.getType(), deleteResponse.getId(), deleteResponse.getSeqNo(),
-                            deleteResponse.getVersion(), deleteResponse.getResult());
+                            deleteResponse.getVersion(), deleteResponse.getResult(), deleteResponse.getTookInNanos());
                         updateResponse.setGetResult(updateHelper.extractGetResult(updateRequest,
                             request.index(), deleteResponse.getVersion(), translate.updatedSourceAsMap(),
                             translate.updateSourceContentType(), null));

--- a/core/src/main/java/org/elasticsearch/action/delete/DeleteResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/delete/DeleteResponse.java
@@ -20,6 +20,7 @@
 package org.elasticsearch.action.delete;
 
 import org.elasticsearch.action.DocWriteResponse;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.shard.ShardId;
@@ -42,7 +43,7 @@ public class DeleteResponse extends DocWriteResponse {
     public DeleteResponse() {
     }
 
-    public DeleteResponse(ShardId shardId, String type, String id, long seqNo, long version, boolean found, long took) {
+    public DeleteResponse(ShardId shardId, String type, String id, long seqNo, long version, boolean found, TimeValue took) {
         super(shardId, type, id, seqNo, version, found ? Result.DELETED : Result.NOT_FOUND, took);
     }
 

--- a/core/src/main/java/org/elasticsearch/action/delete/DeleteResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/delete/DeleteResponse.java
@@ -42,8 +42,8 @@ public class DeleteResponse extends DocWriteResponse {
     public DeleteResponse() {
     }
 
-    public DeleteResponse(ShardId shardId, String type, String id, long seqNo, long version, boolean found) {
-        super(shardId, type, id, seqNo, version, found ? Result.DELETED : Result.NOT_FOUND);
+    public DeleteResponse(ShardId shardId, String type, String id, long seqNo, long version, boolean found, long took) {
+        super(shardId, type, id, seqNo, version, found ? Result.DELETED : Result.NOT_FOUND, took);
     }
 
     @Override
@@ -112,7 +112,7 @@ public class DeleteResponse extends DocWriteResponse {
 
         @Override
         public DeleteResponse build() {
-            DeleteResponse deleteResponse = new DeleteResponse(shardId, type, id, seqNo, version, found);
+            DeleteResponse deleteResponse = new DeleteResponse(shardId, type, id, seqNo, version, found, took);
             deleteResponse.setForcedRefresh(forcedRefresh);
             if (shardInfo != null) {
                 deleteResponse.setShardInfo(shardInfo);

--- a/core/src/main/java/org/elasticsearch/action/index/IndexResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/index/IndexResponse.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.index;
 
 import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.shard.ShardId;
@@ -43,7 +44,7 @@ public class IndexResponse extends DocWriteResponse {
     public IndexResponse() {
     }
 
-    public IndexResponse(ShardId shardId, String type, String id, long seqNo, long version, boolean created, long took) {
+    public IndexResponse(ShardId shardId, String type, String id, long seqNo, long version, boolean created, TimeValue took) {
         super(shardId, type, id, seqNo, version, created ? Result.CREATED : Result.UPDATED, took);
     }
 

--- a/core/src/main/java/org/elasticsearch/action/index/IndexResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/index/IndexResponse.java
@@ -43,8 +43,8 @@ public class IndexResponse extends DocWriteResponse {
     public IndexResponse() {
     }
 
-    public IndexResponse(ShardId shardId, String type, String id, long seqNo, long version, boolean created) {
-        super(shardId, type, id, seqNo, version, created ? Result.CREATED : Result.UPDATED);
+    public IndexResponse(ShardId shardId, String type, String id, long seqNo, long version, boolean created, long took) {
+        super(shardId, type, id, seqNo, version, created ? Result.CREATED : Result.UPDATED, took);
     }
 
     @Override
@@ -114,7 +114,7 @@ public class IndexResponse extends DocWriteResponse {
 
         @Override
         public IndexResponse build() {
-            IndexResponse indexResponse = new IndexResponse(shardId, type, id, seqNo, version, created);
+            IndexResponse indexResponse = new IndexResponse(shardId, type, id, seqNo, version, created, took);
             indexResponse.setForcedRefresh(forcedRefresh);
             if (shardInfo != null) {
                 indexResponse.setShardInfo(shardInfo);

--- a/core/src/main/java/org/elasticsearch/action/update/TransportUpdateAction.java
+++ b/core/src/main/java/org/elasticsearch/action/update/TransportUpdateAction.java
@@ -181,7 +181,7 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
                         ActionListener.<IndexResponse>wrap(response -> {
                             UpdateResponse update = new UpdateResponse(response.getShardInfo(), response.getShardId(),
                                 response.getType(), response.getId(), response.getSeqNo(), response.getVersion(),
-                                response.getResult(), response.getTookInNanos());
+                                response.getResult(), response.getTook());
                             if ((request.fetchSource() != null && request.fetchSource().fetchSource()) ||
                                     (request.fields() != null && request.fields().length > 0)) {
                                 Tuple<XContentType, Map<String, Object>> sourceAndContent =
@@ -204,7 +204,7 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
                         ActionListener.<IndexResponse>wrap(response -> {
                             UpdateResponse update = new UpdateResponse(response.getShardInfo(), response.getShardId(),
                                 response.getType(), response.getId(), response.getSeqNo(), response.getVersion(),
-                                response.getResult(), response.getTookInNanos());
+                                response.getResult(), response.getTook());
                             update.setGetResult(updateHelper.extractGetResult(request, request.concreteIndex(), response.getVersion(), result.updatedSourceAsMap(), result.updateSourceContentType(), indexSourceBytes));
                             update.setForcedRefresh(response.forcedRefresh());
                             listener.onResponse(update);
@@ -217,7 +217,7 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
                         ActionListener.<DeleteResponse>wrap(response -> {
                             UpdateResponse update = new UpdateResponse(response.getShardInfo(), response.getShardId(),
                                 response.getType(), response.getId(), response.getSeqNo(), response.getVersion(),
-                                response.getResult(), response.getTookInNanos());
+                                response.getResult(), response.getTook());
                             update.setGetResult(updateHelper.extractGetResult(request, request.concreteIndex(), response.getVersion(), result.updatedSourceAsMap(), result.updateSourceContentType(), null));
                             update.setForcedRefresh(response.forcedRefresh());
                             listener.onResponse(update);

--- a/core/src/main/java/org/elasticsearch/action/update/TransportUpdateAction.java
+++ b/core/src/main/java/org/elasticsearch/action/update/TransportUpdateAction.java
@@ -179,7 +179,9 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
                 final BytesReference upsertSourceBytes = upsertRequest.source();
                 bulkAction.execute(toSingleItemBulkRequest(upsertRequest), wrapBulkResponse(
                         ActionListener.<IndexResponse>wrap(response -> {
-                            UpdateResponse update = new UpdateResponse(response.getShardInfo(), response.getShardId(), response.getType(), response.getId(), response.getSeqNo(), response.getVersion(), response.getResult());
+                            UpdateResponse update = new UpdateResponse(response.getShardInfo(), response.getShardId(),
+                                response.getType(), response.getId(), response.getSeqNo(), response.getVersion(),
+                                response.getResult(), response.getTookInNanos());
                             if ((request.fetchSource() != null && request.fetchSource().fetchSource()) ||
                                     (request.fields() != null && request.fields().length > 0)) {
                                 Tuple<XContentType, Map<String, Object>> sourceAndContent =
@@ -200,7 +202,9 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
                 final BytesReference indexSourceBytes = indexRequest.source();
                 bulkAction.execute(toSingleItemBulkRequest(indexRequest), wrapBulkResponse(
                         ActionListener.<IndexResponse>wrap(response -> {
-                            UpdateResponse update = new UpdateResponse(response.getShardInfo(), response.getShardId(), response.getType(), response.getId(), response.getSeqNo(), response.getVersion(), response.getResult());
+                            UpdateResponse update = new UpdateResponse(response.getShardInfo(), response.getShardId(),
+                                response.getType(), response.getId(), response.getSeqNo(), response.getVersion(),
+                                response.getResult(), response.getTookInNanos());
                             update.setGetResult(updateHelper.extractGetResult(request, request.concreteIndex(), response.getVersion(), result.updatedSourceAsMap(), result.updateSourceContentType(), indexSourceBytes));
                             update.setForcedRefresh(response.forcedRefresh());
                             listener.onResponse(update);
@@ -211,7 +215,9 @@ public class TransportUpdateAction extends TransportInstanceSingleOperationActio
                 DeleteRequest deleteRequest = result.action();
                 bulkAction.execute(toSingleItemBulkRequest(deleteRequest), wrapBulkResponse(
                         ActionListener.<DeleteResponse>wrap(response -> {
-                            UpdateResponse update = new UpdateResponse(response.getShardInfo(), response.getShardId(), response.getType(), response.getId(), response.getSeqNo(), response.getVersion(), response.getResult());
+                            UpdateResponse update = new UpdateResponse(response.getShardInfo(), response.getShardId(),
+                                response.getType(), response.getId(), response.getSeqNo(), response.getVersion(),
+                                response.getResult(), response.getTookInNanos());
                             update.setGetResult(updateHelper.extractGetResult(request, request.concreteIndex(), response.getVersion(), result.updatedSourceAsMap(), result.updateSourceContentType(), null));
                             update.setForcedRefresh(response.forcedRefresh());
                             listener.onResponse(update);

--- a/core/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
+++ b/core/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
@@ -111,7 +111,7 @@ public class UpdateHelper extends AbstractComponent {
                                 request.script.getIdOrCode());
                     }
                     UpdateResponse update = new UpdateResponse(shardId, getResult.getType(), getResult.getId(),
-                            getResult.getVersion(), DocWriteResponse.Result.NOOP, TimeValue.timeValueNanos(System.nanoTime()-startTime));
+                            getResult.getVersion(), DocWriteResponse.Result.NOOP, TimeValue.timeValueNanos(System.nanoTime() - startTime));
                     update.setGetResult(getResult);
                     return new Result(update, DocWriteResponse.Result.NOOP, upsertDoc, XContentType.JSON);
                 }
@@ -200,13 +200,13 @@ public class UpdateHelper extends AbstractComponent {
             return new Result(deleteRequest, DocWriteResponse.Result.DELETED, updatedSourceAsMap, updateSourceContentType);
         } else if ("none".equals(operation)) {
             UpdateResponse update = new UpdateResponse(shardId, getResult.getType(), getResult.getId(), getResult.getVersion(),
-                DocWriteResponse.Result.NOOP, TimeValue.timeValueNanos(System.nanoTime()-startTime));
+                DocWriteResponse.Result.NOOP, TimeValue.timeValueNanos(System.nanoTime() - startTime));
             update.setGetResult(extractGetResult(request, request.index(), getResult.getVersion(), updatedSourceAsMap, updateSourceContentType, getResult.internalSourceRef()));
             return new Result(update, DocWriteResponse.Result.NOOP, updatedSourceAsMap, updateSourceContentType);
         } else {
             logger.warn("Used update operation [{}] for script [{}], doing nothing...", operation, request.script.getIdOrCode());
             UpdateResponse update = new UpdateResponse(shardId, getResult.getType(), getResult.getId(), getResult.getVersion(),
-                DocWriteResponse.Result.NOOP, TimeValue.timeValueNanos(System.nanoTime()-startTime));
+                DocWriteResponse.Result.NOOP, TimeValue.timeValueNanos(System.nanoTime() - startTime));
             return new Result(update, DocWriteResponse.Result.NOOP, updatedSourceAsMap, updateSourceContentType);
         }
     }

--- a/core/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
+++ b/core/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
@@ -109,7 +109,7 @@ public class UpdateHelper extends AbstractComponent {
                                 request.script.getIdOrCode());
                     }
                     UpdateResponse update = new UpdateResponse(shardId, getResult.getType(), getResult.getId(),
-                            getResult.getVersion(), DocWriteResponse.Result.NOOP);
+                            getResult.getVersion(), DocWriteResponse.Result.NOOP, System.currentTimeMillis() - nowInMillis.getAsLong());
                     update.setGetResult(getResult);
                     return new Result(update, DocWriteResponse.Result.NOOP, upsertDoc, XContentType.JSON);
                 }
@@ -197,12 +197,14 @@ public class UpdateHelper extends AbstractComponent {
                     .setRefreshPolicy(request.getRefreshPolicy());
             return new Result(deleteRequest, DocWriteResponse.Result.DELETED, updatedSourceAsMap, updateSourceContentType);
         } else if ("none".equals(operation)) {
-            UpdateResponse update = new UpdateResponse(shardId, getResult.getType(), getResult.getId(), getResult.getVersion(), DocWriteResponse.Result.NOOP);
+            UpdateResponse update = new UpdateResponse(shardId, getResult.getType(), getResult.getId(), getResult.getVersion(),
+                DocWriteResponse.Result.NOOP, System.currentTimeMillis() - nowInMillis.getAsLong());
             update.setGetResult(extractGetResult(request, request.index(), getResult.getVersion(), updatedSourceAsMap, updateSourceContentType, getResult.internalSourceRef()));
             return new Result(update, DocWriteResponse.Result.NOOP, updatedSourceAsMap, updateSourceContentType);
         } else {
             logger.warn("Used update operation [{}] for script [{}], doing nothing...", operation, request.script.getIdOrCode());
-            UpdateResponse update = new UpdateResponse(shardId, getResult.getType(), getResult.getId(), getResult.getVersion(), DocWriteResponse.Result.NOOP);
+            UpdateResponse update = new UpdateResponse(shardId, getResult.getType(), getResult.getId(), getResult.getVersion(),
+                DocWriteResponse.Result.NOOP, System.currentTimeMillis() - nowInMillis.getAsLong());
             return new Result(update, DocWriteResponse.Result.NOOP, updatedSourceAsMap, updateSourceContentType);
         }
     }

--- a/core/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
+++ b/core/src/main/java/org/elasticsearch/action/update/UpdateHelper.java
@@ -31,6 +31,7 @@ import org.elasticsearch.common.component.AbstractComponent;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.Streamable;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.common.xcontent.XContentType;
@@ -82,6 +83,7 @@ public class UpdateHelper extends AbstractComponent {
      */
     @SuppressWarnings("unchecked")
     protected Result prepare(ShardId shardId, UpdateRequest request, final GetResult getResult, LongSupplier nowInMillis) {
+        Long startTime = System.nanoTime();
         if (!getResult.isExists()) {
             if (request.upsertRequest() == null && !request.docAsUpsert()) {
                 throw new DocumentMissingException(shardId, request.type(), request.id());
@@ -109,7 +111,7 @@ public class UpdateHelper extends AbstractComponent {
                                 request.script.getIdOrCode());
                     }
                     UpdateResponse update = new UpdateResponse(shardId, getResult.getType(), getResult.getId(),
-                            getResult.getVersion(), DocWriteResponse.Result.NOOP, System.currentTimeMillis() - nowInMillis.getAsLong());
+                            getResult.getVersion(), DocWriteResponse.Result.NOOP, TimeValue.timeValueNanos(System.nanoTime()-startTime));
                     update.setGetResult(getResult);
                     return new Result(update, DocWriteResponse.Result.NOOP, upsertDoc, XContentType.JSON);
                 }
@@ -198,13 +200,13 @@ public class UpdateHelper extends AbstractComponent {
             return new Result(deleteRequest, DocWriteResponse.Result.DELETED, updatedSourceAsMap, updateSourceContentType);
         } else if ("none".equals(operation)) {
             UpdateResponse update = new UpdateResponse(shardId, getResult.getType(), getResult.getId(), getResult.getVersion(),
-                DocWriteResponse.Result.NOOP, System.currentTimeMillis() - nowInMillis.getAsLong());
+                DocWriteResponse.Result.NOOP, TimeValue.timeValueNanos(System.nanoTime()-startTime));
             update.setGetResult(extractGetResult(request, request.index(), getResult.getVersion(), updatedSourceAsMap, updateSourceContentType, getResult.internalSourceRef()));
             return new Result(update, DocWriteResponse.Result.NOOP, updatedSourceAsMap, updateSourceContentType);
         } else {
             logger.warn("Used update operation [{}] for script [{}], doing nothing...", operation, request.script.getIdOrCode());
             UpdateResponse update = new UpdateResponse(shardId, getResult.getType(), getResult.getId(), getResult.getVersion(),
-                DocWriteResponse.Result.NOOP, System.currentTimeMillis() - nowInMillis.getAsLong());
+                DocWriteResponse.Result.NOOP, TimeValue.timeValueNanos(System.nanoTime()-startTime));
             return new Result(update, DocWriteResponse.Result.NOOP, updatedSourceAsMap, updateSourceContentType);
         }
     }

--- a/core/src/main/java/org/elasticsearch/action/update/UpdateResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/update/UpdateResponse.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.update;
 import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.index.get.GetResult;
@@ -46,12 +47,12 @@ public class UpdateResponse extends DocWriteResponse {
      * Constructor to be used when a update didn't translate in a write.
      * For example: update script with operation set to none
      */
-    public UpdateResponse(ShardId shardId, String type, String id, long version, Result result, long took) {
+    public UpdateResponse(ShardId shardId, String type, String id, long version, Result result, TimeValue took) {
         this(new ShardInfo(0, 0), shardId, type, id, SequenceNumbersService.UNASSIGNED_SEQ_NO, version, result, took);
     }
 
     public UpdateResponse(ShardInfo shardInfo, ShardId shardId, String type, String id, long seqNo, long version,
-                          Result result, long took) {
+                          Result result, TimeValue took) {
         super(shardId, type, id, seqNo, version, result, took);
         setShardInfo(shardInfo);
     }

--- a/core/src/main/java/org/elasticsearch/action/update/UpdateResponse.java
+++ b/core/src/main/java/org/elasticsearch/action/update/UpdateResponse.java
@@ -46,12 +46,13 @@ public class UpdateResponse extends DocWriteResponse {
      * Constructor to be used when a update didn't translate in a write.
      * For example: update script with operation set to none
      */
-    public UpdateResponse(ShardId shardId, String type, String id, long version, Result result) {
-        this(new ShardInfo(0, 0), shardId, type, id, SequenceNumbersService.UNASSIGNED_SEQ_NO, version, result);
+    public UpdateResponse(ShardId shardId, String type, String id, long version, Result result, long took) {
+        this(new ShardInfo(0, 0), shardId, type, id, SequenceNumbersService.UNASSIGNED_SEQ_NO, version, result, took);
     }
 
-    public UpdateResponse(ShardInfo shardInfo, ShardId shardId, String type, String id, long seqNo, long version, Result result) {
-        super(shardId, type, id, seqNo, version, result);
+    public UpdateResponse(ShardInfo shardInfo, ShardId shardId, String type, String id, long seqNo, long version,
+                          Result result, long took) {
+        super(shardId, type, id, seqNo, version, result, took);
         setShardInfo(shardInfo);
     }
 
@@ -154,9 +155,9 @@ public class UpdateResponse extends DocWriteResponse {
         public UpdateResponse build() {
             UpdateResponse update;
             if (shardInfo != null && seqNo != null) {
-                update = new UpdateResponse(shardInfo, shardId, type, id, seqNo, version, result);
+                update = new UpdateResponse(shardInfo, shardId, type, id, seqNo, version, result, took);
             } else {
-                update = new UpdateResponse(shardId, type, id, version, result);
+                update = new UpdateResponse(shardId, type, id, version, result, took);
             }
             if (getResult != null) {
                 update.setGetResult(new GetResult(update.getIndex(), update.getType(), update.getId(), update.getVersion(),

--- a/core/src/test/java/org/elasticsearch/action/DocWriteResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/DocWriteResponseTests.java
@@ -44,7 +44,8 @@ public class DocWriteResponseTests extends ESTestCase {
                         "id",
                         SequenceNumbersService.UNASSIGNED_SEQ_NO,
                         0,
-                        Result.CREATED) {};
+                        Result.CREATED,
+                        0L) {};
         assertEquals("/index/type/id", response.getLocation(null));
         assertEquals("/index/type/id?routing=test_routing", response.getLocation("test_routing"));
     }
@@ -57,7 +58,8 @@ public class DocWriteResponseTests extends ESTestCase {
                         "❤",
                         SequenceNumbersService.UNASSIGNED_SEQ_NO,
                         0,
-                        Result.CREATED) {};
+                        Result.CREATED,
+                        0L) {};
         assertEquals("/index/type/%E2%9D%A4", response.getLocation(null));
         assertEquals("/index/type/%E2%9D%A4?routing=%C3%A4", response.getLocation("ä"));
     }
@@ -70,7 +72,8 @@ public class DocWriteResponseTests extends ESTestCase {
                         "a b",
                         SequenceNumbersService.UNASSIGNED_SEQ_NO,
                         0,
-                        Result.CREATED) {};
+                        Result.CREATED,
+                        0L) {};
         assertEquals("/index/type/a+b", response.getLocation(null));
         assertEquals("/index/type/a+b?routing=c+d", response.getLocation("c d"));
     }
@@ -87,7 +90,8 @@ public class DocWriteResponseTests extends ESTestCase {
                 "id",
                 SequenceNumbersService.UNASSIGNED_SEQ_NO,
                 0,
-                Result.CREATED) {
+                Result.CREATED,
+                0L) {
                 // DocWriteResponse is abstract so we have to sneak a subclass in here to test it.
             };
         response.setShardInfo(new ShardInfo(1, 1));

--- a/core/src/test/java/org/elasticsearch/action/DocWriteResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/DocWriteResponseTests.java
@@ -46,7 +46,7 @@ public class DocWriteResponseTests extends ESTestCase {
                         SequenceNumbersService.UNASSIGNED_SEQ_NO,
                         0,
                         Result.CREATED,
-                        new TimeValue(0L)) {};
+                        TimeValue.timeValueMillis(0L)) {};
         assertEquals("/index/type/id", response.getLocation(null));
         assertEquals("/index/type/id?routing=test_routing", response.getLocation("test_routing"));
     }
@@ -60,7 +60,7 @@ public class DocWriteResponseTests extends ESTestCase {
                         SequenceNumbersService.UNASSIGNED_SEQ_NO,
                         0,
                         Result.CREATED,
-                        new TimeValue(0L)) {};
+                        TimeValue.timeValueMillis(0L)) {};
         assertEquals("/index/type/%E2%9D%A4", response.getLocation(null));
         assertEquals("/index/type/%E2%9D%A4?routing=%C3%A4", response.getLocation("ä"));
     }
@@ -74,7 +74,7 @@ public class DocWriteResponseTests extends ESTestCase {
                         SequenceNumbersService.UNASSIGNED_SEQ_NO,
                         0,
                         Result.CREATED,
-                        new TimeValue(0L)) {};
+                        TimeValue.timeValueMillis(0L)) {};
         assertEquals("/index/type/a+b", response.getLocation(null));
         assertEquals("/index/type/a+b?routing=c+d", response.getLocation("c d"));
     }
@@ -92,7 +92,7 @@ public class DocWriteResponseTests extends ESTestCase {
                 SequenceNumbersService.UNASSIGNED_SEQ_NO,
                 0,
                 Result.CREATED,
-                new TimeValue(0L)) {
+                TimeValue.timeValueMillis(0L)) {
                 // DocWriteResponse is abstract so we have to sneak a subclass in here to test it.
             };
         response.setShardInfo(new ShardInfo(1, 1));

--- a/core/src/test/java/org/elasticsearch/action/DocWriteResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/DocWriteResponseTests.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action;
 
 import org.elasticsearch.action.DocWriteResponse.Result;
 import org.elasticsearch.action.support.replication.ReplicationResponse.ShardInfo;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.ToXContent;
 import org.elasticsearch.common.xcontent.XContentBuilder;
 import org.elasticsearch.common.xcontent.XContentParser;
@@ -45,7 +46,7 @@ public class DocWriteResponseTests extends ESTestCase {
                         SequenceNumbersService.UNASSIGNED_SEQ_NO,
                         0,
                         Result.CREATED,
-                        0L) {};
+                        new TimeValue(0L)) {};
         assertEquals("/index/type/id", response.getLocation(null));
         assertEquals("/index/type/id?routing=test_routing", response.getLocation("test_routing"));
     }
@@ -59,7 +60,7 @@ public class DocWriteResponseTests extends ESTestCase {
                         SequenceNumbersService.UNASSIGNED_SEQ_NO,
                         0,
                         Result.CREATED,
-                        0L) {};
+                        new TimeValue(0L)) {};
         assertEquals("/index/type/%E2%9D%A4", response.getLocation(null));
         assertEquals("/index/type/%E2%9D%A4?routing=%C3%A4", response.getLocation("ä"));
     }
@@ -73,7 +74,7 @@ public class DocWriteResponseTests extends ESTestCase {
                         SequenceNumbersService.UNASSIGNED_SEQ_NO,
                         0,
                         Result.CREATED,
-                        0L) {};
+                        new TimeValue(0L)) {};
         assertEquals("/index/type/a+b", response.getLocation(null));
         assertEquals("/index/type/a+b?routing=c+d", response.getLocation("c d"));
     }
@@ -91,7 +92,7 @@ public class DocWriteResponseTests extends ESTestCase {
                 SequenceNumbersService.UNASSIGNED_SEQ_NO,
                 0,
                 Result.CREATED,
-                0L) {
+                new TimeValue(0L)) {
                 // DocWriteResponse is abstract so we have to sneak a subclass in here to test it.
             };
         response.setShardInfo(new ShardInfo(1, 1));

--- a/core/src/test/java/org/elasticsearch/action/bulk/BulkRequestModifierTests.java
+++ b/core/src/test/java/org/elasticsearch/action/bulk/BulkRequestModifierTests.java
@@ -118,7 +118,7 @@ public class BulkRequestModifierTests extends ESTestCase {
         for (DocWriteRequest actionRequest : bulkRequest.requests()) {
             IndexRequest indexRequest = (IndexRequest) actionRequest;
             IndexResponse indexResponse = new IndexResponse(new ShardId("index", "_na_", 0), indexRequest.type(),
-                                                               indexRequest.id(), 1, 1, true, new TimeValue(0L));
+                                                               indexRequest.id(), 1, 1, true, TimeValue.timeValueMillis(0L));
             originalResponses.add(new BulkItemResponse(Integer.parseInt(indexRequest.id()), indexRequest.opType(), indexResponse));
         }
         bulkResponseListener.onResponse(new BulkResponse(originalResponses.toArray(new BulkItemResponse[originalResponses.size()]), 0));

--- a/core/src/test/java/org/elasticsearch/action/bulk/BulkRequestModifierTests.java
+++ b/core/src/test/java/org/elasticsearch/action/bulk/BulkRequestModifierTests.java
@@ -117,7 +117,7 @@ public class BulkRequestModifierTests extends ESTestCase {
         for (DocWriteRequest actionRequest : bulkRequest.requests()) {
             IndexRequest indexRequest = (IndexRequest) actionRequest;
             IndexResponse indexResponse = new IndexResponse(new ShardId("index", "_na_", 0), indexRequest.type(),
-                                                               indexRequest.id(), 1, 1, true);
+                                                               indexRequest.id(), 1, 1, true, 0L);
             originalResponses.add(new BulkItemResponse(Integer.parseInt(indexRequest.id()), indexRequest.opType(), indexResponse));
         }
         bulkResponseListener.onResponse(new BulkResponse(originalResponses.toArray(new BulkItemResponse[originalResponses.size()]), 0));

--- a/core/src/test/java/org/elasticsearch/action/bulk/BulkRequestModifierTests.java
+++ b/core/src/test/java/org/elasticsearch/action/bulk/BulkRequestModifierTests.java
@@ -29,6 +29,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.ESTestCase;
@@ -117,7 +118,7 @@ public class BulkRequestModifierTests extends ESTestCase {
         for (DocWriteRequest actionRequest : bulkRequest.requests()) {
             IndexRequest indexRequest = (IndexRequest) actionRequest;
             IndexResponse indexResponse = new IndexResponse(new ShardId("index", "_na_", 0), indexRequest.type(),
-                                                               indexRequest.id(), 1, 1, true, 0L);
+                                                               indexRequest.id(), 1, 1, true, new TimeValue(0L));
             originalResponses.add(new BulkItemResponse(Integer.parseInt(indexRequest.id()), indexRequest.opType(), indexResponse));
         }
         bulkResponseListener.onResponse(new BulkResponse(originalResponses.toArray(new BulkItemResponse[originalResponses.size()]), 0));

--- a/core/src/test/java/org/elasticsearch/action/bulk/TransportShardBulkActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/bulk/TransportShardBulkActionTests.java
@@ -78,14 +78,14 @@ public class TransportShardBulkActionTests extends IndexShardTestCase {
     public void testShouldExecuteReplicaItem() throws Exception {
         // Successful index request should be replicated
         DocWriteRequest writeRequest = new IndexRequest("index", "type", "id").source(Requests.INDEX_CONTENT_TYPE, "foo", "bar");
-        DocWriteResponse response = new IndexResponse(shardId, "type", "id", 1, 1, randomBoolean());
+        DocWriteResponse response = new IndexResponse(shardId, "type", "id", 1, 1, randomBoolean(), 0L);
         BulkItemRequest request = new BulkItemRequest(0, writeRequest);
         request.setPrimaryResponse(new BulkItemResponse(0, DocWriteRequest.OpType.INDEX, response));
         assertTrue(TransportShardBulkAction.shouldExecuteReplicaItem(request, 0));
 
         // Failed index requests should not be replicated (for now!)
         writeRequest = new IndexRequest("index", "type", "id").source(Requests.INDEX_CONTENT_TYPE, "foo", "bar");
-        response = new IndexResponse(shardId, "type", "id", 1, 1, randomBoolean());
+        response = new IndexResponse(shardId, "type", "id", 1, 1, randomBoolean(), 0L);
         request = new BulkItemRequest(0, writeRequest);
         request.setPrimaryResponse(
                 new BulkItemResponse(0, DocWriteRequest.OpType.INDEX,
@@ -94,7 +94,7 @@ public class TransportShardBulkActionTests extends IndexShardTestCase {
 
         // NOOP requests should not be replicated
         writeRequest = new UpdateRequest("index", "type", "id");
-        response = new UpdateResponse(shardId, "type", "id", 1, DocWriteResponse.Result.NOOP);
+        response = new UpdateResponse(shardId, "type", "id", 1, DocWriteResponse.Result.NOOP, 0L);
         request = new BulkItemRequest(0, writeRequest);
         request.setPrimaryResponse(new BulkItemResponse(0, DocWriteRequest.OpType.UPDATE, response));
         assertFalse(TransportShardBulkAction.shouldExecuteReplicaItem(request, 0));
@@ -325,7 +325,7 @@ public class TransportShardBulkActionTests extends IndexShardTestCase {
         DocWriteRequest writeRequest = new IndexRequest("index", "type", "id").source(Requests.INDEX_CONTENT_TYPE, "field", "value");
         BulkItemRequest replicaRequest = new BulkItemRequest(0, writeRequest);
 
-        DocWriteResponse noopUpdateResponse = new UpdateResponse(shardId, "index", "id", 0, DocWriteResponse.Result.NOOP);
+        DocWriteResponse noopUpdateResponse = new UpdateResponse(shardId, "index", "id", 0, DocWriteResponse.Result.NOOP, 0L);
         BulkItemResultHolder noopResults = new BulkItemResultHolder(noopUpdateResponse, null, replicaRequest);
 
         Translog.Location location = new Translog.Location(0, 0, 0);
@@ -416,7 +416,7 @@ public class TransportShardBulkActionTests extends IndexShardTestCase {
         boolean created = randomBoolean();
         Translog.Location resultLocation = new Translog.Location(42, 42, 42);
         Engine.IndexResult indexResult = new FakeResult(1, 1, created, resultLocation);
-        DocWriteResponse indexResponse = new IndexResponse(shardId, "index", "id", 1, 1, created);
+        DocWriteResponse indexResponse = new IndexResponse(shardId, "index", "id", 1, 1, created, 0L);
         BulkItemResultHolder goodResults = new BulkItemResultHolder(indexResponse, indexResult, replicaRequest);
 
         Translog.Location originalLocation = new Translog.Location(21, 21, 21);

--- a/core/src/test/java/org/elasticsearch/action/bulk/TransportShardBulkActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/bulk/TransportShardBulkActionTests.java
@@ -78,14 +78,14 @@ public class TransportShardBulkActionTests extends IndexShardTestCase {
     public void testShouldExecuteReplicaItem() throws Exception {
         // Successful index request should be replicated
         DocWriteRequest writeRequest = new IndexRequest("index", "type", "id").source(Requests.INDEX_CONTENT_TYPE, "foo", "bar");
-        DocWriteResponse response = new IndexResponse(shardId, "type", "id", 1, 1, randomBoolean(), 0L);
+        DocWriteResponse response = new IndexResponse(shardId, "type", "id", 1, 1, randomBoolean(), new TimeValue(0L));
         BulkItemRequest request = new BulkItemRequest(0, writeRequest);
         request.setPrimaryResponse(new BulkItemResponse(0, DocWriteRequest.OpType.INDEX, response));
         assertTrue(TransportShardBulkAction.shouldExecuteReplicaItem(request, 0));
 
         // Failed index requests should not be replicated (for now!)
         writeRequest = new IndexRequest("index", "type", "id").source(Requests.INDEX_CONTENT_TYPE, "foo", "bar");
-        response = new IndexResponse(shardId, "type", "id", 1, 1, randomBoolean(), 0L);
+        response = new IndexResponse(shardId, "type", "id", 1, 1, randomBoolean(), new TimeValue(0L));
         request = new BulkItemRequest(0, writeRequest);
         request.setPrimaryResponse(
                 new BulkItemResponse(0, DocWriteRequest.OpType.INDEX,
@@ -94,7 +94,7 @@ public class TransportShardBulkActionTests extends IndexShardTestCase {
 
         // NOOP requests should not be replicated
         writeRequest = new UpdateRequest("index", "type", "id");
-        response = new UpdateResponse(shardId, "type", "id", 1, DocWriteResponse.Result.NOOP, 0L);
+        response = new UpdateResponse(shardId, "type", "id", 1, DocWriteResponse.Result.NOOP, new TimeValue(0L));
         request = new BulkItemRequest(0, writeRequest);
         request.setPrimaryResponse(new BulkItemResponse(0, DocWriteRequest.OpType.UPDATE, response));
         assertFalse(TransportShardBulkAction.shouldExecuteReplicaItem(request, 0));
@@ -325,7 +325,8 @@ public class TransportShardBulkActionTests extends IndexShardTestCase {
         DocWriteRequest writeRequest = new IndexRequest("index", "type", "id").source(Requests.INDEX_CONTENT_TYPE, "field", "value");
         BulkItemRequest replicaRequest = new BulkItemRequest(0, writeRequest);
 
-        DocWriteResponse noopUpdateResponse = new UpdateResponse(shardId, "index", "id", 0, DocWriteResponse.Result.NOOP, 0L);
+        DocWriteResponse noopUpdateResponse = new UpdateResponse(shardId, "index", "id", 0, DocWriteResponse.Result.NOOP,
+            new TimeValue(0L));
         BulkItemResultHolder noopResults = new BulkItemResultHolder(noopUpdateResponse, null, replicaRequest);
 
         Translog.Location location = new Translog.Location(0, 0, 0);
@@ -416,7 +417,7 @@ public class TransportShardBulkActionTests extends IndexShardTestCase {
         boolean created = randomBoolean();
         Translog.Location resultLocation = new Translog.Location(42, 42, 42);
         Engine.IndexResult indexResult = new FakeResult(1, 1, created, resultLocation);
-        DocWriteResponse indexResponse = new IndexResponse(shardId, "index", "id", 1, 1, created, 0L);
+        DocWriteResponse indexResponse = new IndexResponse(shardId, "index", "id", 1, 1, created, new TimeValue(0L));
         BulkItemResultHolder goodResults = new BulkItemResultHolder(indexResponse, indexResult, replicaRequest);
 
         Translog.Location originalLocation = new Translog.Location(21, 21, 21);

--- a/core/src/test/java/org/elasticsearch/action/bulk/TransportShardBulkActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/bulk/TransportShardBulkActionTests.java
@@ -78,14 +78,14 @@ public class TransportShardBulkActionTests extends IndexShardTestCase {
     public void testShouldExecuteReplicaItem() throws Exception {
         // Successful index request should be replicated
         DocWriteRequest writeRequest = new IndexRequest("index", "type", "id").source(Requests.INDEX_CONTENT_TYPE, "foo", "bar");
-        DocWriteResponse response = new IndexResponse(shardId, "type", "id", 1, 1, randomBoolean(), new TimeValue(0L));
+        DocWriteResponse response = new IndexResponse(shardId, "type", "id", 1, 1, randomBoolean(), TimeValue.timeValueMillis(0L));
         BulkItemRequest request = new BulkItemRequest(0, writeRequest);
         request.setPrimaryResponse(new BulkItemResponse(0, DocWriteRequest.OpType.INDEX, response));
         assertTrue(TransportShardBulkAction.shouldExecuteReplicaItem(request, 0));
 
         // Failed index requests should not be replicated (for now!)
         writeRequest = new IndexRequest("index", "type", "id").source(Requests.INDEX_CONTENT_TYPE, "foo", "bar");
-        response = new IndexResponse(shardId, "type", "id", 1, 1, randomBoolean(), new TimeValue(0L));
+        response = new IndexResponse(shardId, "type", "id", 1, 1, randomBoolean(), TimeValue.timeValueMillis(0L));
         request = new BulkItemRequest(0, writeRequest);
         request.setPrimaryResponse(
                 new BulkItemResponse(0, DocWriteRequest.OpType.INDEX,
@@ -94,7 +94,7 @@ public class TransportShardBulkActionTests extends IndexShardTestCase {
 
         // NOOP requests should not be replicated
         writeRequest = new UpdateRequest("index", "type", "id");
-        response = new UpdateResponse(shardId, "type", "id", 1, DocWriteResponse.Result.NOOP, new TimeValue(0L));
+        response = new UpdateResponse(shardId, "type", "id", 1, DocWriteResponse.Result.NOOP, TimeValue.timeValueMillis(0L));
         request = new BulkItemRequest(0, writeRequest);
         request.setPrimaryResponse(new BulkItemResponse(0, DocWriteRequest.OpType.UPDATE, response));
         assertFalse(TransportShardBulkAction.shouldExecuteReplicaItem(request, 0));
@@ -326,7 +326,7 @@ public class TransportShardBulkActionTests extends IndexShardTestCase {
         BulkItemRequest replicaRequest = new BulkItemRequest(0, writeRequest);
 
         DocWriteResponse noopUpdateResponse = new UpdateResponse(shardId, "index", "id", 0, DocWriteResponse.Result.NOOP,
-            new TimeValue(0L));
+            TimeValue.timeValueMillis(0L));
         BulkItemResultHolder noopResults = new BulkItemResultHolder(noopUpdateResponse, null, replicaRequest);
 
         Translog.Location location = new Translog.Location(0, 0, 0);
@@ -417,7 +417,7 @@ public class TransportShardBulkActionTests extends IndexShardTestCase {
         boolean created = randomBoolean();
         Translog.Location resultLocation = new Translog.Location(42, 42, 42);
         Engine.IndexResult indexResult = new FakeResult(1, 1, created, resultLocation);
-        DocWriteResponse indexResponse = new IndexResponse(shardId, "index", "id", 1, 1, created, new TimeValue(0L));
+        DocWriteResponse indexResponse = new IndexResponse(shardId, "index", "id", 1, 1, created, TimeValue.timeValueMillis(0L));
         BulkItemResultHolder goodResults = new BulkItemResultHolder(indexResponse, indexResult, replicaRequest);
 
         Translog.Location originalLocation = new Translog.Location(21, 21, 21);

--- a/core/src/test/java/org/elasticsearch/action/bulk/byscroll/AsyncBulkByScrollActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/bulk/byscroll/AsyncBulkByScrollActionTests.java
@@ -291,7 +291,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
                 responses[i] = new BulkItemResponse(
                     i,
                     opType,
-                    new IndexResponse(shardId, "type", "id" + i, randomInt(20), randomInt(), createdResponse));
+                    new IndexResponse(shardId, "type", "id" + i, randomInt(20), randomInt(), createdResponse, 0L));
             }
             new DummyAsyncBulkByScrollAction().onBulkResponse(timeValueNanos(System.nanoTime()), new BulkResponse(responses, 0));
             assertEquals(versionConflicts, testTask.getStatus().getVersionConflicts());
@@ -796,11 +796,12 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
                                 index.id(),
                                 randomInt(20),
                                 randomIntBetween(0, Integer.MAX_VALUE),
-                                true);
+                                true,
+                                0L);
                     } else if (item instanceof UpdateRequest) {
                         UpdateRequest update = (UpdateRequest) item;
                         response = new UpdateResponse(shardId, update.type(), update.id(),
-                                randomIntBetween(0, Integer.MAX_VALUE), Result.CREATED);
+                                randomIntBetween(0, Integer.MAX_VALUE), Result.CREATED, 0L);
                     } else if (item instanceof DeleteRequest) {
                         DeleteRequest delete = (DeleteRequest) item;
                         response =
@@ -810,7 +811,7 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
                                 delete.id(),
                                 randomInt(20),
                                 randomIntBetween(0, Integer.MAX_VALUE),
-                                true);
+                                true, 0L);
                     } else {
                         throw new RuntimeException("Unknown request:  " + item);
                     }

--- a/core/src/test/java/org/elasticsearch/action/bulk/byscroll/AsyncBulkByScrollActionTests.java
+++ b/core/src/test/java/org/elasticsearch/action/bulk/byscroll/AsyncBulkByScrollActionTests.java
@@ -104,6 +104,7 @@ import static java.util.Collections.singletonList;
 import static java.util.Collections.synchronizedSet;
 import static org.apache.lucene.util.TestUtil.randomSimpleString;
 import static org.elasticsearch.action.bulk.BackoffPolicy.constantBackoff;
+import static org.elasticsearch.common.unit.TimeValue.parseTimeValue;
 import static org.elasticsearch.common.unit.TimeValue.timeValueMillis;
 import static org.elasticsearch.common.unit.TimeValue.timeValueNanos;
 import static org.elasticsearch.common.unit.TimeValue.timeValueSeconds;
@@ -291,7 +292,8 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
                 responses[i] = new BulkItemResponse(
                     i,
                     opType,
-                    new IndexResponse(shardId, "type", "id" + i, randomInt(20), randomInt(), createdResponse, 0L));
+                    new IndexResponse(shardId, "type", "id" + i, randomInt(20), randomInt(), createdResponse,
+                        parseTimeValue(randomPositiveTimeValue(), "test")));
             }
             new DummyAsyncBulkByScrollAction().onBulkResponse(timeValueNanos(System.nanoTime()), new BulkResponse(responses, 0));
             assertEquals(versionConflicts, testTask.getStatus().getVersionConflicts());
@@ -797,11 +799,15 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
                                 randomInt(20),
                                 randomIntBetween(0, Integer.MAX_VALUE),
                                 true,
-                                0L);
+                                parseTimeValue(randomPositiveTimeValue(), "test"));
                     } else if (item instanceof UpdateRequest) {
                         UpdateRequest update = (UpdateRequest) item;
-                        response = new UpdateResponse(shardId, update.type(), update.id(),
-                                randomIntBetween(0, Integer.MAX_VALUE), Result.CREATED, 0L);
+                        response = new UpdateResponse(
+                                shardId,
+                                update.type(),
+                                update.id(),
+                                randomIntBetween(0, Integer.MAX_VALUE),
+                                Result.CREATED, parseTimeValue(randomPositiveTimeValue(), "test"));
                     } else if (item instanceof DeleteRequest) {
                         DeleteRequest delete = (DeleteRequest) item;
                         response =
@@ -811,7 +817,8 @@ public class AsyncBulkByScrollActionTests extends ESTestCase {
                                 delete.id(),
                                 randomInt(20),
                                 randomIntBetween(0, Integer.MAX_VALUE),
-                                true, 0L);
+                                true,
+                                parseTimeValue(randomPositiveTimeValue(), "test"));
                     } else {
                         throw new RuntimeException("Unknown request:  " + item);
                     }

--- a/core/src/test/java/org/elasticsearch/action/delete/DeleteResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/delete/DeleteResponseTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.action.support.replication.ReplicationResponse;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.seqno.SequenceNumbersService;
@@ -34,22 +35,26 @@ import java.io.IOException;
 
 import static org.elasticsearch.action.index.IndexResponseTests.assertDocWriteResponse;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.INDEX_UUID_NA_VALUE;
+import static org.elasticsearch.common.unit.TimeValue.parseTimeValue;
 import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
 
 public class DeleteResponseTests extends ESTestCase {
 
     public void testToXContent() {
         {
-            DeleteResponse response = new DeleteResponse(new ShardId("index", "index_uuid", 0), "type", "id", 3, 5, true, 0L);
+            DeleteResponse response = new DeleteResponse(new ShardId("index", "index_uuid", 0), "type", "id", 3, 5, true,
+                TimeValue.timeValueMillis(55555));
             String output = Strings.toString(response);
             assertEquals("{\"found\":true,\"_index\":\"index\",\"_type\":\"type\",\"_id\":\"id\",\"_version\":5,\"result\":\"deleted\"," +
-                "\"took\":0,\"_shards\":null,\"_seq_no\":3}", output);
+                "\"took\":55555,\"_shards\":null,\"_seq_no\":3}", output);
         }
         {
-            DeleteResponse response = new DeleteResponse(new ShardId("index", "index_uuid", 0), "type", "id", -1, 7, true, 0L);
+            DeleteResponse response = new DeleteResponse(new ShardId("index", "index_uuid", 0), "type", "id", -1, 7, true,
+                TimeValue.timeValueNanos(54321));
             response.setForcedRefresh(true);
             response.setShardInfo(new ReplicationResponse.ShardInfo(10, 5));
             String output = Strings.toString(response);
+            // Took expected to be 0 due to conversion from nanosecond to millisecond for value 54321
             assertEquals("{\"found\":true,\"_index\":\"index\",\"_type\":\"type\",\"_id\":\"id\",\"_version\":7,\"result\":\"deleted\"," +
                 "\"took\":0,\"forced_refresh\":true,\"_shards\":{\"total\":10,\"successful\":5,\"failed\":0}}", output);
         }
@@ -100,14 +105,15 @@ public class DeleteResponseTests extends ESTestCase {
         long version = randomBoolean() ? randomNonNegativeLong() : randomIntBetween(0, 10000);
         boolean found = randomBoolean();
         boolean forcedRefresh = randomBoolean();
+        TimeValue took = parseTimeValue(randomPositiveTimeValue(), "test");
 
         Tuple<ReplicationResponse.ShardInfo, ReplicationResponse.ShardInfo> shardInfos = RandomObjects.randomShardInfo(random());
 
-        DeleteResponse actual = new DeleteResponse(new ShardId(index, indexUUid, shardId), type, id, seqNo, version, found, 0L);
+        DeleteResponse actual = new DeleteResponse(new ShardId(index, indexUUid, shardId), type, id, seqNo, version, found, took);
         actual.setForcedRefresh(forcedRefresh);
         actual.setShardInfo(shardInfos.v1());
 
-        DeleteResponse expected = new DeleteResponse(new ShardId(index, INDEX_UUID_NA_VALUE, -1), type, id, seqNo, version, found, 0L);
+        DeleteResponse expected = new DeleteResponse(new ShardId(index, INDEX_UUID_NA_VALUE, -1), type, id, seqNo, version, found, took);
         expected.setForcedRefresh(forcedRefresh);
         expected.setShardInfo(shardInfos.v2());
 

--- a/core/src/test/java/org/elasticsearch/action/delete/DeleteResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/delete/DeleteResponseTests.java
@@ -40,18 +40,18 @@ public class DeleteResponseTests extends ESTestCase {
 
     public void testToXContent() {
         {
-            DeleteResponse response = new DeleteResponse(new ShardId("index", "index_uuid", 0), "type", "id", 3, 5, true);
+            DeleteResponse response = new DeleteResponse(new ShardId("index", "index_uuid", 0), "type", "id", 3, 5, true, 0L);
             String output = Strings.toString(response);
             assertEquals("{\"found\":true,\"_index\":\"index\",\"_type\":\"type\",\"_id\":\"id\",\"_version\":5,\"result\":\"deleted\"," +
-                "\"_shards\":null,\"_seq_no\":3}", output);
+                "\"took\":0,\"_shards\":null,\"_seq_no\":3}", output);
         }
         {
-            DeleteResponse response = new DeleteResponse(new ShardId("index", "index_uuid", 0), "type", "id", -1, 7, true);
+            DeleteResponse response = new DeleteResponse(new ShardId("index", "index_uuid", 0), "type", "id", -1, 7, true, 0L);
             response.setForcedRefresh(true);
             response.setShardInfo(new ReplicationResponse.ShardInfo(10, 5));
             String output = Strings.toString(response);
             assertEquals("{\"found\":true,\"_index\":\"index\",\"_type\":\"type\",\"_id\":\"id\",\"_version\":7,\"result\":\"deleted\"," +
-                "\"forced_refresh\":true,\"_shards\":{\"total\":10,\"successful\":5,\"failed\":0}}", output);
+                "\"took\":0,\"forced_refresh\":true,\"_shards\":{\"total\":10,\"successful\":5,\"failed\":0}}", output);
         }
     }
 
@@ -103,11 +103,11 @@ public class DeleteResponseTests extends ESTestCase {
 
         Tuple<ReplicationResponse.ShardInfo, ReplicationResponse.ShardInfo> shardInfos = RandomObjects.randomShardInfo(random());
 
-        DeleteResponse actual = new DeleteResponse(new ShardId(index, indexUUid, shardId), type, id, seqNo, version, found);
+        DeleteResponse actual = new DeleteResponse(new ShardId(index, indexUUid, shardId), type, id, seqNo, version, found, 0L);
         actual.setForcedRefresh(forcedRefresh);
         actual.setShardInfo(shardInfos.v1());
 
-        DeleteResponse expected = new DeleteResponse(new ShardId(index, INDEX_UUID_NA_VALUE, -1), type, id, seqNo, version, found);
+        DeleteResponse expected = new DeleteResponse(new ShardId(index, INDEX_UUID_NA_VALUE, -1), type, id, seqNo, version, found, 0L);
         expected.setForcedRefresh(forcedRefresh);
         expected.setShardInfo(shardInfos.v2());
 

--- a/core/src/test/java/org/elasticsearch/action/index/IndexRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/index/IndexRequestTests.java
@@ -135,7 +135,9 @@ public class IndexRequestTests extends ESTestCase {
         String id = randomAsciiOfLengthBetween(3, 10);
         long version = randomLong();
         boolean created = randomBoolean();
-        IndexResponse indexResponse = new IndexResponse(shardId, type, id, SequenceNumbersService.UNASSIGNED_SEQ_NO, version, created);
+        long took = randomNonNegativeLong();
+        IndexResponse indexResponse = new IndexResponse(shardId, type, id, SequenceNumbersService.UNASSIGNED_SEQ_NO,
+            version, created, took);
         int total = randomIntBetween(1, 10);
         int successful = randomIntBetween(1, 10);
         ReplicationResponse.ShardInfo shardInfo = new ReplicationResponse.ShardInfo(total, successful);

--- a/core/src/test/java/org/elasticsearch/action/index/IndexRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/index/IndexRequestTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.action.support.replication.ReplicationResponse;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.index.VersionType;
@@ -40,6 +41,7 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
@@ -135,7 +137,7 @@ public class IndexRequestTests extends ESTestCase {
         String id = randomAsciiOfLengthBetween(3, 10);
         long version = randomLong();
         boolean created = randomBoolean();
-        long took = randomNonNegativeLong();
+        TimeValue took = TimeValue.timeValueNanos(randomNonNegativeLong());
         IndexResponse indexResponse = new IndexResponse(shardId, type, id, SequenceNumbersService.UNASSIGNED_SEQ_NO,
             version, created, took);
         int total = randomIntBetween(1, 10);

--- a/core/src/test/java/org/elasticsearch/action/index/IndexResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/index/IndexResponseTests.java
@@ -41,18 +41,18 @@ public class IndexResponseTests extends ESTestCase {
 
     public void testToXContent() {
         {
-            IndexResponse indexResponse = new IndexResponse(new ShardId("index", "index_uuid", 0), "type", "id", 3, 5, true);
+            IndexResponse indexResponse = new IndexResponse(new ShardId("index", "index_uuid", 0), "type", "id", 3, 5, true, 0L);
             String output = Strings.toString(indexResponse);
-            assertEquals("{\"_index\":\"index\",\"_type\":\"type\",\"_id\":\"id\",\"_version\":5,\"result\":\"created\",\"_shards\":null," +
-                    "\"_seq_no\":3,\"created\":true}", output);
+            assertEquals("{\"_index\":\"index\",\"_type\":\"type\",\"_id\":\"id\",\"_version\":5,\"result\":\"created\"," +
+                "\"took\":0,\"_shards\":null,\"_seq_no\":3,\"created\":true}", output);
         }
         {
-            IndexResponse indexResponse = new IndexResponse(new ShardId("index", "index_uuid", 0), "type", "id", -1, 7, true);
+            IndexResponse indexResponse = new IndexResponse(new ShardId("index", "index_uuid", 0), "type", "id", -1, 7, true, 0L);
             indexResponse.setForcedRefresh(true);
             indexResponse.setShardInfo(new ReplicationResponse.ShardInfo(10, 5));
             String output = Strings.toString(indexResponse);
             assertEquals("{\"_index\":\"index\",\"_type\":\"type\",\"_id\":\"id\",\"_version\":7,\"result\":\"created\"," +
-                    "\"forced_refresh\":true,\"_shards\":{\"total\":10,\"successful\":5,\"failed\":0},\"created\":true}", output);
+                "\"took\":0,\"forced_refresh\":true,\"_shards\":{\"total\":10,\"successful\":5,\"failed\":0},\"created\":true}", output);
         }
     }
 
@@ -113,14 +113,15 @@ public class IndexResponseTests extends ESTestCase {
         long version = randomBoolean() ? randomNonNegativeLong() : randomIntBetween(0, 10000);
         boolean created = randomBoolean();
         boolean forcedRefresh = randomBoolean();
+        long took = randomBoolean() ? randomNonNegativeLong() : randomIntBetween(0, 10000);
 
         Tuple<ReplicationResponse.ShardInfo, ReplicationResponse.ShardInfo> shardInfos = RandomObjects.randomShardInfo(random());
 
-        IndexResponse actual = new IndexResponse(new ShardId(index, indexUUid, shardId), type, id, seqNo, version, created);
+        IndexResponse actual = new IndexResponse(new ShardId(index, indexUUid, shardId), type, id, seqNo, version, created, took);
         actual.setForcedRefresh(forcedRefresh);
         actual.setShardInfo(shardInfos.v1());
 
-        IndexResponse expected = new IndexResponse(new ShardId(index, INDEX_UUID_NA_VALUE, -1), type, id, seqNo, version, created);
+        IndexResponse expected = new IndexResponse(new ShardId(index, INDEX_UUID_NA_VALUE, -1), type, id, seqNo, version, created, took);
         expected.setForcedRefresh(forcedRefresh);
         expected.setShardInfo(shardInfos.v2());
 

--- a/core/src/test/java/org/elasticsearch/action/update/UpdateResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/update/UpdateResponseTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.get.GetField;
@@ -44,23 +45,26 @@ import static org.elasticsearch.action.DocWriteResponse.Result.DELETED;
 import static org.elasticsearch.action.DocWriteResponse.Result.NOT_FOUND;
 import static org.elasticsearch.action.DocWriteResponse.Result.UPDATED;
 import static org.elasticsearch.cluster.metadata.IndexMetaData.INDEX_UUID_NA_VALUE;
+import static org.elasticsearch.common.unit.TimeValue.parseTimeValue;
 import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
 
 public class UpdateResponseTests extends ESTestCase {
 
     public void testToXContent() throws IOException {
         {
-            UpdateResponse updateResponse = new UpdateResponse(new ShardId("index", "index_uuid", 0), "type", "id", 0, NOT_FOUND, 0L);
+            UpdateResponse updateResponse = new UpdateResponse(new ShardId("index", "index_uuid", 0), "type", "id", 0, NOT_FOUND,
+                TimeValue.timeValueMillis(56789));
             String output = Strings.toString(updateResponse);
             assertEquals("{\"_index\":\"index\",\"_type\":\"type\",\"_id\":\"id\",\"_version\":0,\"result\":\"not_found\"," +
-                    "\"took\":0,\"_shards\":{\"total\":0,\"successful\":0,\"failed\":0}}", output);
+                    "\"took\":56789,\"_shards\":{\"total\":0,\"successful\":0,\"failed\":0}}", output);
         }
         {
             UpdateResponse updateResponse = new UpdateResponse(new ReplicationResponse.ShardInfo(10, 6),
-                    new ShardId("index", "index_uuid", 1), "type", "id", 3, 1, DELETED, 0L);
+                    new ShardId("index", "index_uuid", 1), "type", "id", 3, 1, DELETED,
+                TimeValue.timeValueMillis(98765));
             String output = Strings.toString(updateResponse);
             assertEquals("{\"_index\":\"index\",\"_type\":\"type\",\"_id\":\"id\",\"_version\":1,\"result\":\"deleted\"," +
-                    "\"took\":0,\"_shards\":{\"total\":10,\"successful\":6,\"failed\":0},\"_seq_no\":3}", output);
+                    "\"took\":98765,\"_shards\":{\"total\":10,\"successful\":6,\"failed\":0},\"_seq_no\":3}", output);
         }
         {
             BytesReference source = new BytesArray("{\"title\":\"Book title\",\"isbn\":\"ABC-123\"}");
@@ -69,12 +73,13 @@ public class UpdateResponseTests extends ESTestCase {
             fields.put("isbn", new GetField("isbn", Collections.singletonList("ABC-123")));
 
             UpdateResponse updateResponse = new UpdateResponse(new ReplicationResponse.ShardInfo(3, 2),
-                    new ShardId("books", "books_uuid", 2), "book", "1", 7, 2, UPDATED, 0L);
+                    new ShardId("books", "books_uuid", 2), "book", "1", 7, 2, UPDATED,
+                TimeValue.timeValueMillis(99999));
             updateResponse.setGetResult(new GetResult("books", "book", "1", 2, true, source, fields));
 
             String output = Strings.toString(updateResponse);
             assertEquals("{\"_index\":\"books\",\"_type\":\"book\",\"_id\":\"1\",\"_version\":2,\"result\":\"updated\"," +
-                    "\"took\":0,\"_shards\":{\"total\":3,\"successful\":2,\"failed\":0},\"_seq_no\":7,\"get\":{\"found\":true," +
+                    "\"took\":99999,\"_shards\":{\"total\":3,\"successful\":2,\"failed\":0},\"_seq_no\":7,\"get\":{\"found\":true," +
                     "\"_source\":{\"title\":\"Book title\",\"isbn\":\"ABC-123\"},\"fields\":{\"isbn\":[\"ABC-123\"],\"title\":[\"Book " +
                     "title\"]}}}", output);
         }
@@ -132,6 +137,7 @@ public class UpdateResponseTests extends ESTestCase {
         DocWriteResponse.Result result = actualGetResult.isExists() ? DocWriteResponse.Result.UPDATED : DocWriteResponse.Result.NOT_FOUND;
         String indexUUid = randomAsciiOfLength(5);
         int shardId = randomIntBetween(0, 5);
+        TimeValue took = parseTimeValue(randomPositiveTimeValue(), "test");
 
         // We also want small number values (randomNonNegativeLong() tend to generate high numbers)
         // in order to catch some conversion error that happen between int/long after parsing.
@@ -144,11 +150,11 @@ public class UpdateResponseTests extends ESTestCase {
         if (seqNo != null) {
             Tuple<ReplicationResponse.ShardInfo, ReplicationResponse.ShardInfo> shardInfos = RandomObjects.randomShardInfo(random());
 
-            actual = new UpdateResponse(shardInfos.v1(), actualShardId, type, id, seqNo, version, result, 0L);
-            expected = new UpdateResponse(shardInfos.v2(), expectedShardId, type, id, seqNo, version, result, 0L);
+            actual = new UpdateResponse(shardInfos.v1(), actualShardId, type, id, seqNo, version, result, took);
+            expected = new UpdateResponse(shardInfos.v2(), expectedShardId, type, id, seqNo, version, result, took);
         } else {
-            actual = new UpdateResponse(actualShardId, type, id, version, result, 0L);
-            expected = new UpdateResponse(expectedShardId, type, id, version, result, 0L);
+            actual = new UpdateResponse(actualShardId, type, id, version, result, took);
+            expected = new UpdateResponse(expectedShardId, type, id, version, result, took);
         }
 
         if (actualGetResult.isExists()) {

--- a/core/src/test/java/org/elasticsearch/action/update/UpdateResponseTests.java
+++ b/core/src/test/java/org/elasticsearch/action/update/UpdateResponseTests.java
@@ -50,17 +50,17 @@ public class UpdateResponseTests extends ESTestCase {
 
     public void testToXContent() throws IOException {
         {
-            UpdateResponse updateResponse = new UpdateResponse(new ShardId("index", "index_uuid", 0), "type", "id", 0, NOT_FOUND);
+            UpdateResponse updateResponse = new UpdateResponse(new ShardId("index", "index_uuid", 0), "type", "id", 0, NOT_FOUND, 0L);
             String output = Strings.toString(updateResponse);
             assertEquals("{\"_index\":\"index\",\"_type\":\"type\",\"_id\":\"id\",\"_version\":0,\"result\":\"not_found\"," +
-                    "\"_shards\":{\"total\":0,\"successful\":0,\"failed\":0}}", output);
+                    "\"took\":0,\"_shards\":{\"total\":0,\"successful\":0,\"failed\":0}}", output);
         }
         {
             UpdateResponse updateResponse = new UpdateResponse(new ReplicationResponse.ShardInfo(10, 6),
-                    new ShardId("index", "index_uuid", 1), "type", "id", 3, 1, DELETED);
+                    new ShardId("index", "index_uuid", 1), "type", "id", 3, 1, DELETED, 0L);
             String output = Strings.toString(updateResponse);
             assertEquals("{\"_index\":\"index\",\"_type\":\"type\",\"_id\":\"id\",\"_version\":1,\"result\":\"deleted\"," +
-                    "\"_shards\":{\"total\":10,\"successful\":6,\"failed\":0},\"_seq_no\":3}", output);
+                    "\"took\":0,\"_shards\":{\"total\":10,\"successful\":6,\"failed\":0},\"_seq_no\":3}", output);
         }
         {
             BytesReference source = new BytesArray("{\"title\":\"Book title\",\"isbn\":\"ABC-123\"}");
@@ -69,12 +69,12 @@ public class UpdateResponseTests extends ESTestCase {
             fields.put("isbn", new GetField("isbn", Collections.singletonList("ABC-123")));
 
             UpdateResponse updateResponse = new UpdateResponse(new ReplicationResponse.ShardInfo(3, 2),
-                    new ShardId("books", "books_uuid", 2), "book", "1", 7, 2, UPDATED);
+                    new ShardId("books", "books_uuid", 2), "book", "1", 7, 2, UPDATED, 0L);
             updateResponse.setGetResult(new GetResult("books", "book", "1", 2, true, source, fields));
 
             String output = Strings.toString(updateResponse);
             assertEquals("{\"_index\":\"books\",\"_type\":\"book\",\"_id\":\"1\",\"_version\":2,\"result\":\"updated\"," +
-                    "\"_shards\":{\"total\":3,\"successful\":2,\"failed\":0},\"_seq_no\":7,\"get\":{\"found\":true," +
+                    "\"took\":0,\"_shards\":{\"total\":3,\"successful\":2,\"failed\":0},\"_seq_no\":7,\"get\":{\"found\":true," +
                     "\"_source\":{\"title\":\"Book title\",\"isbn\":\"ABC-123\"},\"fields\":{\"isbn\":[\"ABC-123\"],\"title\":[\"Book " +
                     "title\"]}}}", output);
         }
@@ -144,11 +144,11 @@ public class UpdateResponseTests extends ESTestCase {
         if (seqNo != null) {
             Tuple<ReplicationResponse.ShardInfo, ReplicationResponse.ShardInfo> shardInfos = RandomObjects.randomShardInfo(random());
 
-            actual = new UpdateResponse(shardInfos.v1(), actualShardId, type, id, seqNo, version, result);
-            expected = new UpdateResponse(shardInfos.v2(), expectedShardId, type, id, seqNo, version, result);
+            actual = new UpdateResponse(shardInfos.v1(), actualShardId, type, id, seqNo, version, result, 0L);
+            expected = new UpdateResponse(shardInfos.v2(), expectedShardId, type, id, seqNo, version, result, 0L);
         } else {
-            actual = new UpdateResponse(actualShardId, type, id, version, result);
-            expected = new UpdateResponse(expectedShardId, type, id, version, result);
+            actual = new UpdateResponse(actualShardId, type, id, version, result, 0L);
+            expected = new UpdateResponse(expectedShardId, type, id, version, result, 0L);
         }
 
         if (actualGetResult.isExists()) {

--- a/core/src/test/java/org/elasticsearch/index/replication/ESIndexLevelReplicationTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/replication/ESIndexLevelReplicationTestCase.java
@@ -52,6 +52,7 @@ import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.TestShardRouting;
 import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.TimeValue;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.engine.Engine;
@@ -560,7 +561,7 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
             indexResult.getSeqNo(),
             indexResult.getVersion(),
             indexResult.isCreated(),
-            indexResult.getTook());
+            TimeValue.timeValueNanos(indexResult.getTook()));
     }
 
     /**

--- a/core/src/test/java/org/elasticsearch/index/replication/ESIndexLevelReplicationTestCase.java
+++ b/core/src/test/java/org/elasticsearch/index/replication/ESIndexLevelReplicationTestCase.java
@@ -559,7 +559,8 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
             request.id(),
             indexResult.getSeqNo(),
             indexResult.getVersion(),
-            indexResult.isCreated());
+            indexResult.isCreated(),
+            indexResult.getTook());
     }
 
     /**

--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -97,6 +97,7 @@ The result of this bulk operation is:
             "_id": "1",
             "_version": 1,
             "result": "created",
+            "took" : 0,
             "_shards": {
                "total": 2,
                "successful": 1,
@@ -115,6 +116,7 @@ The result of this bulk operation is:
             "_id": "2",
             "_version": 1,
             "result": "not_found",
+            "took" : 1,
             "_shards": {
                "total": 2,
                "successful": 1,
@@ -131,6 +133,7 @@ The result of this bulk operation is:
             "_id": "3",
             "_version": 1,
             "result": "created",
+            "took" : 2,
             "_shards": {
                "total": 2,
                "successful": 1,
@@ -148,6 +151,7 @@ The result of this bulk operation is:
             "_id": "1",
             "_version": 2,
             "result": "updated",
+            "took" : 3,
             "_shards": {
                 "total": 2,
                 "successful": 1,
@@ -160,7 +164,7 @@ The result of this bulk operation is:
    ]
 }
 --------------------------------------------------
-// TESTRESPONSE[s/"took": 30/"took": $body.took/ s/"index_uuid": .../"index_uuid": $body.items.3.update.error.index_uuid/ s/"_seq_no" : 0/"_seq_no" : $body.items.0.index._seq_no/ s/"_seq_no" : 1/"_seq_no" : $body.items.1.delete._seq_no/ s/"_seq_no" : 2/"_seq_no" : $body.items.2.create._seq_no/ s/"_seq_no" : 3/"_seq_no" : $body.items.3.update._seq_no/]
+// TESTRESPONSE[s/"took": 30/"took": $body.took/ s/"index_uuid": .../"index_uuid": $body.items.3.update.error.index_uuid/ s/"_seq_no" : 0/"_seq_no" : $body.items.0.index._seq_no/ s/"_seq_no" : 1/"_seq_no" : $body.items.1.delete._seq_no/ s/"_seq_no" : 2/"_seq_no" : $body.items.2.create._seq_no/ s/"_seq_no" : 3/"_seq_no" : $body.items.3.update._seq_no/ s/"took" : 0/"took" : $body.items.0.index.took/ s/"took" : 1/"took" : $body.items.1.delete.took/ s/"took" : 2/"took" : $body.items.2.create.took/ s/"took" : 3/"took" : $body.items.3.update.took/]
 
 The endpoints are `/_bulk`, `/{index}/_bulk`, and `{index}/{type}/_bulk`.
 When the index or the index/type are provided, they will be used by

--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -164,7 +164,16 @@ The result of this bulk operation is:
    ]
 }
 --------------------------------------------------
-// TESTRESPONSE[s/"took": 30/"took": $body.took/ s/"index_uuid": .../"index_uuid": $body.items.3.update.error.index_uuid/ s/"_seq_no" : 0/"_seq_no" : $body.items.0.index._seq_no/ s/"_seq_no" : 1/"_seq_no" : $body.items.1.delete._seq_no/ s/"_seq_no" : 2/"_seq_no" : $body.items.2.create._seq_no/ s/"_seq_no" : 3/"_seq_no" : $body.items.3.update._seq_no/ s/"took" : 0/"took" : $body.items.0.index.took/ s/"took" : 1/"took" : $body.items.1.delete.took/ s/"took" : 2/"took" : $body.items.2.create.took/ s/"took" : 3/"took" : $body.items.3.update.took/]
+// TESTRESPONSE[s/"took": 30/"took": $body.took/]
+// TESTRESPONSE[s/"index_uuid": .../"index_uuid": $body.items.3.update.error.index_uuid/]
+// TESTRESPONSE[s/"_seq_no" : 0/"_seq_no" : $body.items.0.index._seq_no/]
+// TESTRESPONSE[s/"_seq_no" : 1/"_seq_no" : $body.items.1.delete._seq_no/]
+// TESTRESPONSE[s/"_seq_no" : 2/"_seq_no" : $body.items.2.create._seq_no/]
+// TESTRESPONSE[s/"_seq_no" : 3/"_seq_no" : $body.items.3.update._seq_no/]
+// TESTRESPONSE[s/"took" : 0/"took" : $body.items.0.index.took/]
+// TESTRESPONSE[s/"took" : 1/"took" : $body.items.1.delete.took/]
+// TESTRESPONSE[s/"took" : 2/"took" : $body.items.2.create.took/]
+// TESTRESPONSE[s/"took" : 3/"took" : $body.items.3.update.took/]
 
 The endpoints are `/_bulk`, `/{index}/_bulk`, and `{index}/{type}/_bulk`.
 When the index or the index/type are provided, they will be used by

--- a/docs/reference/docs/index_.asciidoc
+++ b/docs/reference/docs/index_.asciidoc
@@ -36,7 +36,8 @@ The result of the above index operation is:
     "took" : 0
 }
 --------------------------------------------------
-// TESTRESPONSE[s/"successful" : 2/"successful" : 1/ s/"took" : 0/"took" : $body.took/]
+// TESTRESPONSE[s/"successful" : 2/"successful" : 1/]
+// TESTRESPONSE[s/"took" : 0/"took" : $body.took/]
 
 The `_shards` header provides information about the replication process of the index operation.
 
@@ -235,8 +236,9 @@ The result of the above index operation is:
     "took" : 0
 }
 --------------------------------------------------
-// TESTRESPONSE[s/6a8ca01c-7896-48e9-81cc-9f70661fcb32/$body._id/ s/"successful" : 2/"successful" : 1/ s/"took" : 0/"took" : $body.took/]
-
+// TESTRESPONSE[s/6a8ca01c-7896-48e9-81cc-9f70661fcb32/$body._id/]
+// TESTRESPONSE[s/"successful" : 2/"successful" : 1/]
+// TESTRESPONSE[s/"took" : 0/"took" : $body.took/]
 
 [float]
 [[index-routing]]

--- a/docs/reference/docs/index_.asciidoc
+++ b/docs/reference/docs/index_.asciidoc
@@ -32,10 +32,11 @@ The result of the above index operation is:
     "_version" : 1,
     "created" : true,
     "_seq_no" : 0,
-    "result" : created
+    "result" : created,
+    "took" : 0
 }
 --------------------------------------------------
-// TESTRESPONSE[s/"successful" : 2/"successful" : 1/]
+// TESTRESPONSE[s/"successful" : 2/"successful" : 1/ s/"took" : 0/"took" : $body.took/]
 
 The `_shards` header provides information about the replication process of the index operation.
 
@@ -230,10 +231,12 @@ The result of the above index operation is:
     "_version" : 1,
     "created" : true,
     "_seq_no" : 0,
-    "result": "created"
+    "result": "created",
+    "took" : 0
 }
 --------------------------------------------------
-// TESTRESPONSE[s/6a8ca01c-7896-48e9-81cc-9f70661fcb32/$body._id/ s/"successful" : 2/"successful" : 1/]
+// TESTRESPONSE[s/6a8ca01c-7896-48e9-81cc-9f70661fcb32/$body._id/ s/"successful" : 2/"successful" : 1/ s/"took" : 0/"took" : $body.took/]
+
 
 [float]
 [[index-routing]]

--- a/docs/reference/docs/update.asciidoc
+++ b/docs/reference/docs/update.asciidoc
@@ -170,10 +170,11 @@ the request was ignored.
    "_type": "type1",
    "_id": "1",
    "_version": 6,
-   "result": noop
+   "result": noop,
+   "took": 0
 }
 --------------------------------------------------
-// TESTRESPONSE
+// TESTRESPONSE[s/"took": 0/"took": $body.took/]
 
 You can disable this behavior by setting "detect_noop": false like this:
 

--- a/docs/reference/getting-started.asciidoc
+++ b/docs/reference/getting-started.asciidoc
@@ -326,7 +326,8 @@ And the response:
   "_seq_no" : 0
 }
 --------------------------------------------------
-// TESTRESPONSE[s/"_seq_no" : 0/"_seq_no" : $body._seq_no/ s/"took" : 0/"took" : $body.took/]
+// TESTRESPONSE[s/"_seq_no" : 0/"_seq_no" : $body._seq_no/]
+// TESTRESPONSE[s/"took" : 0/"took" : $body.took/]
 
 From the above, we can see that a new customer document was successfully created inside the customer index and the external type. The document also has an internal id of 1 which we specified at index time.
 

--- a/docs/reference/getting-started.asciidoc
+++ b/docs/reference/getting-started.asciidoc
@@ -316,6 +316,7 @@ And the response:
   "_id" : "1",
   "_version" : 1,
   "result" : "created",
+  "took" : 0,
   "_shards" : {
     "total" : 2,
     "successful" : 1,
@@ -325,7 +326,7 @@ And the response:
   "_seq_no" : 0
 }
 --------------------------------------------------
-// TESTRESPONSE[s/"_seq_no" : 0/"_seq_no" : $body._seq_no/]
+// TESTRESPONSE[s/"_seq_no" : 0/"_seq_no" : $body._seq_no/ s/"took" : 0/"took" : $body.took/]
 
 From the above, we can see that a new customer document was successfully created inside the customer index and the external type. The document also has an internal id of 1 which we specified at index time.
 

--- a/docs/reference/ingest/ingest-node.asciidoc
+++ b/docs/reference/ingest/ingest-node.asciidoc
@@ -900,6 +900,7 @@ PUT /myindex/type/1?pipeline=monthlyindex
   "_id" : "1",
   "_version" : 1,
   "result" : "created",
+  "took" : 0,
   "_shards" : {
     "total" : 2,
     "successful" : 1,
@@ -909,7 +910,7 @@ PUT /myindex/type/1?pipeline=monthlyindex
   "_seq_no" : 0
 }
 --------------------------------------------------
-// TESTRESPONSE
+// TESTRESPONSE[s/"took" : 0/"took" : $body.took/]
 
 
 The above request will not index this document into the `myindex` index, but into the `myindex-2016-04-01` index because

--- a/docs/reference/query-dsl/percolate-query.asciidoc
+++ b/docs/reference/query-dsl/percolate-query.asciidoc
@@ -182,10 +182,11 @@ Index response:
   },
   "created": true,
   "result": "created",
-  "_seq_no" : 1
+  "_seq_no" : 1,
+  "took" : 0
 }
 --------------------------------------------------
-// TESTRESPONSE
+// TESTRESPONSE[s/"took" : 0/"took" : $body.took/]
 
 Percolating an existing document, using the index response as basis to build to new search request:
 


### PR DESCRIPTION
**Changes**
- Added field for took time in DocWriteResponse, stored in nanoseconds.
- `readFrom()` and `writeTo()` in DocWriteResponse will only handle `took` values from v6.0 alpha1 onwards to ensure backwards compatibility.
- `innerToXContent()` will include `took` as a field with the value measured in milliseconds (for readability) if it is greater than or equal to 0 (i.e. not `UNASSIGNED_TOOK_TIME`).
- Attempted to simulate took time in UpdateHelper by calculating the difference between current system time with the `nowInMillis` argument variable.
- Modified `.asciidoc` files under `docs/reference/` directory to update the rules for satisfying expected values due to updated output format
- Modified existing test cases to include the `took` value in the constructor. 

Closes issue 16641