### PR TITLE
Add keepAlive limit of 5 minutes for Scroll searches and adjust tests…

### DIFF
--- a/core/src/main/java/org/elasticsearch/search/Scroll.java
+++ b/core/src/main/java/org/elasticsearch/search/Scroll.java
@@ -38,18 +38,28 @@ public final class Scroll implements Writeable {
     private final TimeValue keepAlive;
 
     public Scroll(StreamInput in) throws IOException {
-        this.keepAlive = new TimeValue(in);
-    }
+        TimeValue keepAlive = new TimeValue(in);
+        Objects.requireNonNull(keepAlive,"keepAlive must not be null");
+        if(keepAlive.seconds() > 300){
+            throw new IllegalArgumentException("Keep Alive values are restricted to 5 minutes or less.");
+        }
+        this.keepAlive = keepAlive;
+}
 
     /**
      * Constructs a new scroll of the provided keep alive.
      */
     public Scroll(TimeValue keepAlive) {
-        this.keepAlive = Objects.requireNonNull(keepAlive, "keepAlive must not be null");
+        Objects.requireNonNull(keepAlive,"keepAlive must not be null");
+
+        if(keepAlive.seconds() > 300){
+            throw new IllegalArgumentException("Keep Alive values are restricted to 5 minutes or less.");
+        }
+        this.keepAlive = keepAlive;
     }
 
     /**
-     * How long the resources will be kept open to support the scroll request.
+     * How long the resources will be kept open to support the scroll request. Restricted to a 5 minute maximum.
      */
     public TimeValue keepAlive() {
         return keepAlive;

--- a/core/src/main/java/org/elasticsearch/search/Scroll.java
+++ b/core/src/main/java/org/elasticsearch/search/Scroll.java
@@ -36,13 +36,12 @@ import java.util.Objects;
 public final class Scroll implements Writeable {
 
     private final TimeValue keepAlive;
+    public static final int TIMEOUT_SECONDS = 300;
+    public static final TimeValue TIMEOUT_MAX = TimeValue.timeValueSeconds(TIMEOUT_SECONDS);
 
     public Scroll(StreamInput in) throws IOException {
         TimeValue keepAlive = new TimeValue(in);
-        Objects.requireNonNull(keepAlive,"keepAlive must not be null");
-        if(keepAlive.seconds() > 300){
-            throw new IllegalArgumentException("Keep Alive values are restricted to 5 minutes or less.");
-        }
+        checkKeepAlive(keepAlive);
         this.keepAlive = keepAlive;
 }
 
@@ -51,11 +50,18 @@ public final class Scroll implements Writeable {
      */
     public Scroll(TimeValue keepAlive) {
         Objects.requireNonNull(keepAlive,"keepAlive must not be null");
+        checkKeepAlive(keepAlive);
+        this.keepAlive = keepAlive;
+    }
 
-        if(keepAlive.seconds() > 300){
+    /**
+     * Check the validity of the submitted KeepAlive value
+     *
+     */
+    public void checkKeepAlive(TimeValue keepAlive){
+        if(keepAlive.seconds() > TIMEOUT_MAX.seconds()) {
             throw new IllegalArgumentException("Keep Alive values are restricted to 5 minutes or less.");
         }
-        this.keepAlive = keepAlive;
     }
 
     /**

--- a/core/src/test/java/org/elasticsearch/action/search/SearchScrollRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/search/SearchScrollRequestTests.java
@@ -66,7 +66,16 @@ public class SearchScrollRequestTests extends ESTestCase {
 
     public static SearchScrollRequest createSearchScrollRequest() {
         SearchScrollRequest searchScrollRequest = new SearchScrollRequest(randomAsciiOfLengthBetween(3, 10));
-        searchScrollRequest.scroll(randomPositiveTimeValue());
+
+        TimeValue randomKeepAlive;
+        String randomTimeValue;
+        //Ensure that random time value does not conflict with 5 minute keepAlive limitation
+        do {
+            randomTimeValue = randomPositiveTimeValue();
+            randomKeepAlive = TimeValue.parseTimeValue(randomTimeValue, null, "OTHER:Randomizing Scroll Timeout Value");
+        } while (randomKeepAlive.seconds() > 300);
+
+        searchScrollRequest.scroll(randomTimeValue);
         return searchScrollRequest;
     }
 

--- a/core/src/test/java/org/elasticsearch/action/search/SearchScrollRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/action/search/SearchScrollRequestTests.java
@@ -22,6 +22,7 @@ package org.elasticsearch.action.search;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.search.Scroll;
 import org.elasticsearch.search.internal.InternalScrollSearchRequest;
 import org.elasticsearch.test.ESTestCase;
 
@@ -73,7 +74,7 @@ public class SearchScrollRequestTests extends ESTestCase {
         do {
             randomTimeValue = randomPositiveTimeValue();
             randomKeepAlive = TimeValue.parseTimeValue(randomTimeValue, null, "OTHER:Randomizing Scroll Timeout Value");
-        } while (randomKeepAlive.seconds() > 300);
+        } while (randomKeepAlive.seconds() > Scroll.TIMEOUT_SECONDS);
 
         searchScrollRequest.scroll(randomTimeValue);
         return searchScrollRequest;

--- a/core/src/test/java/org/elasticsearch/search/internal/ShardSearchTransportRequestTests.java
+++ b/core/src/test/java/org/elasticsearch/search/internal/ShardSearchTransportRequestTests.java
@@ -188,7 +188,8 @@ public class ShardSearchTransportRequestTests extends AbstractSearchTestCase {
         try (StreamInput in = new NamedWriteableAwareStreamInput(requestBytes.streamInput(), namedWriteableRegistry)) {
             in.setVersion(Version.V_5_0_0);
             ShardSearchTransportRequest readRequest = new ShardSearchTransportRequest();
-            readRequest.readFrom(in);
+            //Old test does not comply with 5 minute timeout max, requires change of serialized code to resolve
+            expectThrows(IllegalArgumentException.class, () ->readRequest.readFrom(in));
             assertEquals(0, in.available());
             IllegalStateException illegalStateException = expectThrows(IllegalStateException.class, () -> readRequest.filteringAliases());
             assertEquals("alias filter for aliases: [JSOOSFfZxE, UjLlLkjwWh, uBpgtwuqDG] must be rewritten first",

--- a/core/src/test/java/org/elasticsearch/search/scroll/SearchScrollIT.java
+++ b/core/src/test/java/org/elasticsearch/search/scroll/SearchScrollIT.java
@@ -525,4 +525,15 @@ public class SearchScrollIT extends ESIntegTestCase {
         assertThat(map.get("succeeded"), is(succeed));
         assertThat(map.get("num_freed"), equalTo(numFreed));
     }
+    
+    public void testTimeoutLimitOnScroll() throws Exception {
+        
+         Throwable exception = expectThrows(IllegalArgumentException.class, () -> client().prepareSearch()
+                 .setQuery(matchAllQuery())
+                 .setSize(35)
+                 .setScroll(TimeValue.timeValueMinutes(6))
+                 .addSort("field", SortOrder.ASC)
+                 .execute().actionGet());
+          assertEquals("Keep Alive values are restricted to 5 minutes or less.",exception.getMessage());
+    }
 }

--- a/test/framework/src/main/java/org/elasticsearch/search/RandomSearchRequestGenerator.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/RandomSearchRequestGenerator.java
@@ -98,7 +98,15 @@ public class RandomSearchRequestGenerator {
             searchRequest.routing(randomAsciiOfLengthBetween(3, 10));
         }
         if (randomBoolean()) {
-            searchRequest.scroll(randomPositiveTimeValue());
+            TimeValue randomKeepAlive;
+            String randomTimeValue;
+            //Ensure that random time value does not conflict with 5 minute keepAlive limitation
+            do {
+                randomTimeValue = randomPositiveTimeValue();
+                randomKeepAlive = TimeValue.parseTimeValue(randomTimeValue, null, "OTHER:Randomizing Scroll Timeout Value");
+            } while (randomKeepAlive.seconds() > 300);
+
+            searchRequest.scroll(randomTimeValue);
         }
         if (randomBoolean()) {
             searchRequest.searchType(randomFrom(SearchType.values()));
@@ -135,7 +143,14 @@ public class RandomSearchRequestGenerator {
             builder.minScore(randomFloat() * 1000);
         }
         if (randomBoolean()) {
-            builder.timeout(TimeValue.parseTimeValue(randomTimeValue(), null, "timeout"));
+            //Only accept randomly generated TimeValues up to 5 minutes
+            TimeValue timeout;
+            do {
+                timeout = TimeValue.parseTimeValue(randomTimeValue(), null, "timeout");
+            }
+            while(timeout.seconds() > 300);
+
+            builder.timeout(timeout);
         }
         if (randomBoolean()) {
             builder.terminateAfter(randomIntBetween(1, 100000));

--- a/test/framework/src/main/java/org/elasticsearch/search/RandomSearchRequestGenerator.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/RandomSearchRequestGenerator.java
@@ -104,7 +104,7 @@ public class RandomSearchRequestGenerator {
             do {
                 randomTimeValue = randomPositiveTimeValue();
                 randomKeepAlive = TimeValue.parseTimeValue(randomTimeValue, null, "OTHER:Randomizing Scroll Timeout Value");
-            } while (randomKeepAlive.seconds() > 300);
+            } while (randomKeepAlive.seconds() > Scroll.TIMEOUT_SECONDS);
 
             searchRequest.scroll(randomTimeValue);
         }


### PR DESCRIPTION
An exception is thrown if a keepAlive value of over 5 minutes is input for a scroll search.
Various tests have been adjusted to ensure they don't use invalid keepAlive values.
They were changed with minimal interference to high level functions.

An additional test was added to check whether invalid values over 5 minutes would throw an exception and correctly end.

The test "testSerialize50Request" of the ShardSearchTransportRequestTests class does not pass as it now submits an invalid keepAlive value, which cannot be edited manually as the request is only accessible in its serialized form. This test needs to either be deleted or replaced with a valid serialized test request.
It causes an AssertionError as the stream is not read and the request is aborted upon submitting its keepAlive value.

Closes issue 23268


