### PR TITLE
Fix issue 23436: RangeQuery values near Long.MAX_VALUE incorrectly processed

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/joda/DateMathParser.java
+++ b/core/src/main/java/org/elasticsearch/common/joda/DateMathParser.java
@@ -189,14 +189,19 @@ public class DateMathParser {
 
     private long parseDateTime(String value, DateTimeZone timeZone, boolean roundUpIfNoTime) {
         DateTimeFormatter parser = dateTimeFormatter.parser();
+        Boolean roundUp = roundUpIfNoTime;
         if (timeZone != null) {
             parser = parser.withZone(timeZone);
         }
         try {
             MutableDateTime date;
+            //Check for edge case that causes Long overflow
+            if (this.dateTimeFormatter.format().contains("epoch_millis") && this.isLong(value)){
+                roundUp = false;
+            }
             // We use 01/01/1970 as a base date so that things keep working with date
             // fields that are filled with times without dates
-            if (roundUpIfNoTime) {
+            if (roundUp) {
                 date = new MutableDateTime(1970, 1, 1, 23, 59, 59, 999, DateTimeZone.UTC);
             } else {
                 date = new MutableDateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeZone.UTC);
@@ -212,6 +217,27 @@ public class DateMathParser {
         } catch (IllegalArgumentException e) {
             throw new ElasticsearchParseException("failed to parse date field [{}] with format [{}]", e, value, dateTimeFormatter.format());
         }
+    }
+
+    //Will return false if string is longer that Long.MAX_VALUE
+    private boolean isLong(String string) {
+        if (string == null || string.isEmpty()) {
+            return false;
+        }
+        int i = 0;
+        if (string.charAt(0) == '-') {
+            if (string.length() > 1) {
+                i++;
+            } else {
+                return false;
+            }
+        }
+        for (; i < string.length(); i++) {
+            if (!Character.isDigit(string.charAt(i))) {
+                return false;
+            }
+        }
+        return true;
     }
 
 }


### PR DESCRIPTION
When performing a RangeQuery with dates using an epoch string. Values near Long.MAX_VALUE will cause returned results to be incorrect. 

Example Query:
```
{
  "query": {
    "range": {
      "test_date": {
        "from": null,
        "to": 9223372036854775807,
        "include_lower": true,
        "include_upper": true
      }
    }
  }
}
```
Caused by parseDateTime in DateMathParser:
- Parser adds 23:59:59:999 (hh:mm:ss:mil) to dates without times based on roundUpIfNoTime boolean input. This boolean input is based off the include_upper/include_lower in the query which is valid except in the case of an epoch string. If input epoch value is within the 24h window, the parser will return an overflowed value (near Long.MIN_VALUE).
- Default parse format is "strict_date_optional_time||epoch_millis". It is unknown what format the input is until the parse is attempted.

Fix:
Add a small check to not use time offset when parse parameter "epoch_millis" and input is valid Long regardless of include_(lower/upper).