### PR TITLE
Fix 21862 : Improve the validation check for the field name and its mapping 

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -176,6 +176,12 @@ final class DocumentParser {
 
     private static String[] splitAndValidatePath(String fullFieldPath) {
         String[] parts = fullFieldPath.split("\\.");
+        // the parts array will have 0 elements if the split was not successful,
+        // for example in this case if the string was a single dot '.'
+        if (parts.length == 0) {
+            throw new IllegalArgumentException(
+                    "unable to construct and validate a path from the filed name: [" + fullFieldPath + "]");
+        }
         for (String part : parts) {
             if (Strings.hasText(part) == false) {
                 throw new IllegalArgumentException(

--- a/core/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/ObjectMapper.java
@@ -274,6 +274,9 @@ public class ObjectMapper extends Mapper implements Cloneable {
                         throw new MapperParsingException("No handler for type [" + type + "] declared on field [" + fieldName + "]");
                     }
                     String[] fieldNameParts = fieldName.split("\\.");
+                    if (fieldNameParts.length == 0) {
+                        throw new MapperParsingException("Invalid field name [" + fieldName + "] for type [" + type + "]");
+                    }
                     String realFieldName = fieldNameParts[fieldNameParts.length - 1];
                     Mapper.Builder<?,?> fieldBuilder = typeParser.parse(realFieldName, propNode, parserContext);
                     for (int i = fieldNameParts.length - 2; i >= 0; --i) {

--- a/core/src/test/java/org/elasticsearch/index/mapper/DocumentMapperParserTests.java
+++ b/core/src/test/java/org/elasticsearch/index/mapper/DocumentMapperParserTests.java
@@ -38,7 +38,19 @@ public class DocumentMapperParserTests extends ESSingleNodeTestCase {
         DocumentMapper mapper = parser.parse("type", new CompressedXContent(mapping));
         assertThat(mapper.type(), equalTo("type"));
     }
-
+    
+    public void testInvalidFiledName() throws Exception {
+        IndexService indexService = createIndex("test");
+        DocumentMapperParser mapperParser = indexService.mapperService().documentMapperParser();
+        String mapping = XContentFactory.jsonBuilder().startObject().startObject("type").startObject("properties")
+                .startObject(".").field("type", "text").endObject()
+                .startObject("foo").field("type", "text").endObject()
+                .endObject().endObject().endObject().string();
+        MapperParsingException e = expectThrows(MapperParsingException.class,
+                () -> mapperParser.parse("type", new CompressedXContent(mapping)));
+        assertEquals("Invalid field name [.] for type [text]", e.getMessage());
+    }
+    
     public void testFieldNameWithDots() throws Exception {
         IndexService indexService = createIndex("test");
         DocumentMapperParser mapperParser = indexService.mapperService().documentMapperParser();


### PR DESCRIPTION
**Changes:**
Check the length of the string array returned after splitting `fullFieldPath` (path provided by the user). The splitting is done to interpret the path from the field name as described [here](https://www.elastic.co/guide/en/elasticsearch/reference/2.4/dots-in-names.html). The array will not contain any element if the splitting was unsuccessful resulting in an `ArrayIndexOutOfBounds` exception. 

**Why:**
Rather than complaining the user about an `ArrayIndexOutOfBounds` exception, now it provides a clear message that the provided field name is invalid.

_Fixes the issue 21862_