### PR TITLE
Fixed issue #21974 - Query param

### DIFF
--- a/Coordination.md
+++ b/Coordination.md
@@ -3,16 +3,19 @@ Note: number of pull requests has changed to 2-3 per group due to changes to ass
 Issue number: group name (no links to elasticsearch, just the number - sort by issue number)
 5042: jk
 5341: 100
+9538: Krispy Belgian Cookies
 10096: jk
 12315: Oink
 13260: jk
 16564: Oink
 17597: 100
 17620: JAH
+18109: Krispy Belgian Cookies
 18348: JAH
 18515: Group 1
 18543: Oink
 20912: Evil_Engineers
+21974: Krispy Belgian Cookies
 21978: Group SmallBit
 22209: JTeam1
 22530: Evil_Engineers

--- a/core/src/main/java/org/elasticsearch/rest/RestRequest.java
+++ b/core/src/main/java/org/elasticsearch/rest/RestRequest.java
@@ -76,6 +76,7 @@ public abstract class RestRequest implements ToXContent.Params {
             this.rawPath = uri;
         } else {
             this.rawPath = uri.substring(0, pathEndPos);
+
             String percentUri;
             // If the query ends with a %, change it to %25 rather than trying to resolve the encoding.
             if (uri.substring(uri.length() - 1).equals("%"))
@@ -86,6 +87,7 @@ public abstract class RestRequest implements ToXContent.Params {
             {
                 percentUri = uri;
             }
+
             RestUtils.decodeQueryString(percentUri, pathEndPos + 1, params);
         }
         this.params = params;

--- a/core/src/main/java/org/elasticsearch/rest/RestRequest.java
+++ b/core/src/main/java/org/elasticsearch/rest/RestRequest.java
@@ -76,7 +76,17 @@ public abstract class RestRequest implements ToXContent.Params {
             this.rawPath = uri;
         } else {
             this.rawPath = uri.substring(0, pathEndPos);
-            RestUtils.decodeQueryString(uri, pathEndPos + 1, params);
+            String percentUri;
+            // If the query ends with a %, change it to %25 rather than trying to resolve the encoding.
+            if (uri.substring(uri.length() - 1).equals("%"))
+            {
+                percentUri = uri + "25";
+            }
+            else
+            {
+                percentUri = uri;
+            }
+            RestUtils.decodeQueryString(percentUri, pathEndPos + 1, params);
         }
         this.params = params;
         this.headers = Collections.unmodifiableMap(headers);

--- a/core/src/main/java/org/elasticsearch/rest/RestRequest.java
+++ b/core/src/main/java/org/elasticsearch/rest/RestRequest.java
@@ -76,7 +76,6 @@ public abstract class RestRequest implements ToXContent.Params {
             this.rawPath = uri;
         } else {
             this.rawPath = uri.substring(0, pathEndPos);
-
             String percentUri;
             // If the query ends with a %, change it to %25 rather than trying to resolve the encoding.
             if (uri.substring(uri.length() - 1).equals("%"))


### PR DESCRIPTION
Invalid queries that end with a "%" symbol such as http://localhost9200/?% (query part: /?%), threw out an exception to the server 
and did not give a formatted message to the client. Fix has been implemented so that a formatted error message will be sent to the client.

The fix was implemented an if-else statement that swapped any "%" symbol that is found at the end of a query 
to "%25" (the correct encoding for "%" symbol). The modified query is then passed back to Elasticsearch which carries on with the usual functionality

