### PR TITLE
8362: Log number of required candidates on failure

### DIFF
--- a/core/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
+++ b/core/src/main/java/org/elasticsearch/discovery/zen/ZenDiscovery.java
@@ -910,7 +910,7 @@ public class ZenDiscovery extends AbstractLifecycleComponent implements Discover
                 return winner.getNode();
             } else {
                 // if we don't have enough master nodes, we bail, because there are not enough master to elect from
-                logger.trace("not enough master nodes [{}]", masterCandidates);
+                logger.trace("not enough master nodes [{}], expected at least [{}]", masterCandidates, electMaster.minimumMasterNodes());
                 return null;
             }
         } else {


### PR DESCRIPTION
Fixes issue 8362 by logging the number of candidates that were expected when said number is not met.
