### PR TITLE
Bug fix for cat aliases not returning any records when querying with multiple alias names

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesRequest.java
@@ -35,17 +35,17 @@ public class GetAliasesRequest extends MasterNodeReadRequest<GetAliasesRequest> 
 
     private IndicesOptions indicesOptions = IndicesOptions.strictExpand();
     
-    public GetAliasesRequest(String[] aliases){
-        this.aliases=aliases;
+    public GetAliasesRequest(String[] aliases) {
+        this.aliases = aliases;
     }
     
     public GetAliasesRequest(String alias) {
-        // String alias can contains multiple aliases separated by commas. 
-        // Alias names cannot contains ',', hence don't need to worry about splitting the alias name. 
-        if(alias.contains(",")){
+        // String alias can contain multiple aliases separated by commas. 
+        // Alias names cannot contain ',', thus, don't need to worry about splitting the alias name. 
+        if (alias.contains(",")) {
             this.aliases = alias.split(",");
-        }else{ 
-            this.aliases= new String[]{alias};
+        } else { 
+            this.aliases = new String[]{alias};
         }
     }
 

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesRequest.java
@@ -34,13 +34,19 @@ public class GetAliasesRequest extends MasterNodeReadRequest<GetAliasesRequest> 
     private String[] aliases = Strings.EMPTY_ARRAY;
 
     private IndicesOptions indicesOptions = IndicesOptions.strictExpand();
-
-    public GetAliasesRequest(String[] aliases) {
-        this.aliases = aliases;
+    
+    public GetAliasesRequest(String[] aliases){
+        this.aliases=aliases;
     }
-
+    
     public GetAliasesRequest(String alias) {
-        this.aliases = new String[]{alias};
+        // String alias can contains multiple aliases separated by commas. 
+        // Alias names cannot contains ',', hence don't need to worry about splitting the alias name. 
+        if(alias.contains(",")){
+            this.aliases = alias.split(",");
+        }else{ 
+            this.aliases= new String[]{alias};
+        }
     }
 
     public GetAliasesRequest() {

--- a/core/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesRequest.java
@@ -34,11 +34,11 @@ public class GetAliasesRequest extends MasterNodeReadRequest<GetAliasesRequest> 
     private String[] aliases = Strings.EMPTY_ARRAY;
 
     private IndicesOptions indicesOptions = IndicesOptions.strictExpand();
-    
+
     public GetAliasesRequest(String[] aliases) {
         this.aliases = aliases;
     }
-    
+
     public GetAliasesRequest(String alias) {
         // String alias can contain multiple aliases separated by commas. 
         // Alias names cannot contain ',', thus, don't need to worry about splitting the alias name. 

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.aliases.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.aliases.json
@@ -8,7 +8,7 @@
       "parts": {
         "name": {
           "type" : "string",
-          "description" : "A string representing a list of alias name separated by commas"
+          "description" : "A comma-separated list of alias names to return"
         }
       },
       "params": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.aliases.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.aliases.json
@@ -7,8 +7,8 @@
       "paths": ["/_cat/aliases", "/_cat/aliases/{name}"],
       "parts": {
         "name": {
-          "type" : "list",
-          "description" : "A comma-separated list of alias names to return"
+          "type" : "string",
+          "description" : "A string representing a list of alias name separated by commas"
         }
       },
       "params": {


### PR DESCRIPTION
Updated the GetAliasesRequest constructor (in GetAliasesRequest.java) to properly handle multiple aliases.
Also updated [cat.aliases.json](https://github.com/elastic/elasticsearch/blob/6265ef1c1ba1d308bcc28d00dccccac555e33b89/rest-api-spec/src/main/resources/rest-api-spec/api/cat.aliases.json#L9-L12) to document {name} as a string of comma-separated alias names instead of a list.
Closes issue 23661. 