### PR TITLE
Fail hard if .yml exists in 5.0.0

### DIFF
--- a/core/src/main/java/org/elasticsearch/node/internal/InternalSettingsPreparer.java
+++ b/core/src/main/java/org/elasticsearch/node/internal/InternalSettingsPreparer.java
@@ -46,7 +46,7 @@ import static org.elasticsearch.common.Strings.cleanPath;
  */
 public class InternalSettingsPreparer {
 
-    private static final String[] ALLOWED_SUFFIXES = {".yml", ".yaml", ".json"};
+    private static final String[] ALLOWED_SUFFIXES = {".yaml", ".json"};
     static final String PROPERTY_DEFAULTS_PREFIX = "default.";
     static final Predicate<String> PROPERTY_DEFAULTS_PREDICATE = key -> key.startsWith(PROPERTY_DEFAULTS_PREFIX);
 
@@ -101,7 +101,8 @@ public class InternalSettingsPreparer {
                     try {
                         output.loadFromPath(path);
                     } catch (IOException e) {
-                        throw new SettingsException("Failed to load settings from " + path.toString(), e);
+                        throw new SettingsException("Failed to load settings from " + path.toString() + ". Allowed " +
+                            "settings suffixes: .yaml and .json (.yml is no longer supported in ES5.0).", e);
                     }
                 }
                 settingsFileFound = true;

--- a/core/src/test/java/org/elasticsearch/node/internal/InternalSettingsPreparerTests.java
+++ b/core/src/test/java/org/elasticsearch/node/internal/InternalSettingsPreparerTests.java
@@ -137,7 +137,8 @@ public class InternalSettingsPreparerTests extends ESTestCase {
                 .put(baseEnvSettings)
                 .build(), null);
         } catch (SettingsException e) {
-            assertEquals("Failed to load settings from [elasticsearch.yml]", e.getMessage());
+            assertEquals("Failed to load settings from [elasticsearch.yml]" + ". Allowed " +
+                "settings suffixes: .yaml and .json (.yml is no longer supported in ES5.0).", e.getMessage());
         }
     }
 


### PR DESCRIPTION
Fixes "Fail hard if .yml exists in 5.0.0" in issue 19391.

Changes made:

- .yml removed from list of allowed suffixes in ES5.0
- Updated exception error message so that it now notifies users that .yml is no longer supported. (only .yaml and .json are)
- updated test class with aforementioned error message