### PR TITLE
Closed Issue 23673, Documented preserveExisting parameter setting

### DIFF
--- a/docs/reference/indices/update-settings.asciidoc
+++ b/docs/reference/indices/update-settings.asciidoc
@@ -101,3 +101,9 @@ POST /twitter/_open
 --------------------------------------------------
 // CONSOLE
 // TEST[setup:twitter]
+
+===Preserve Existing setting during update
+
+If the 'preserveExisting' parameter is set to true existing settings on the respective index remain unchanged.
+The default value is false.
+-----------------------------------------------------


### PR DESCRIPTION
A new parameter, 'preserveExisting' ,was added earlier to preserve existing settings when doing setting update. If the parameter is set to true, existing settings on an index remain unchanged. The default value of the parameter is false.

This was not documented and this pull request documents the above mentioned functionality.