### PR TITLE
Added validation exception for when a scroll search returns a size of 0.

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/search/SearchRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/search/SearchRequest.java
@@ -21,6 +21,7 @@ package org.elasticsearch.action.search;
 
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import static org.elasticsearch.action.ValidateActions.addValidationError;
 import org.elasticsearch.action.IndicesRequest;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.Nullable;
@@ -100,9 +101,19 @@ public final class SearchRequest extends ActionRequest implements IndicesRequest
         this.source = source;
     }
 
+    /**
+     * Adds new validation exception to list of exception when size of scroll search is 0. Returns exception with message to throw.
+     */
     @Override
     public ActionRequestValidationException validate() {
-        return null;
+        //No instantiation of new ActionRequestValidationException yet as calling function checks for null.
+        ActionRequestValidationException vException = null;
+        //Only add this new validation exception when conditions are met (i.e. when a scroll search returns a size of 0.)
+        if ((scroll != null) && (source.size() == 0)) {
+            //Create this validation exception and add to existing list of validation exceptions
+            vException = addValidationError("Error: size is 0! Cannot use scroll search", null);
+        }
+        return vException;
     }
 
     /**

--- a/core/src/test/java/org/elasticsearch/search/scroll/SearchScrollIT.java
+++ b/core/src/test/java/org/elasticsearch/search/scroll/SearchScrollIT.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.search.scroll;
 
+import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.search.ClearScrollResponse;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
@@ -112,6 +113,16 @@ public class SearchScrollIT extends ESIntegTestCase {
         } finally {
             clearScroll(searchResponse.getScrollId());
         }
+    }
+
+    public void testScrollSearchSize() throws Exception {
+        Throwable exception = expectThrows(ActionRequestValidationException.class, () -> client().prepareSearch()
+                .setQuery(matchAllQuery())
+                .setSize(0)
+                .setScroll(TimeValue.timeValueMinutes(2))
+                .execute().actionGet());
+
+        assertEquals("Validation Failed: 1: Error: size is 0! Cannot use scroll search;", exception.getMessage());
     }
 
     public void testSimpleScrollQueryThenFetchSmallSizeUnevenDistribution() throws Exception {


### PR DESCRIPTION
A scroll query search does not make sense if the size specified and returned is 0. Thus a validation exception should be thrown when the size is 0.

A test case for when the size is 0 is included. A test for valid input is NOT included as it is redundant. The other test cases in the test suite already tests for valid scroll queries multiple times.

Have run "gradle check" with no problems.

 - Added new ValidationException for when a scroll query has a size of 0
 - Included new test case to check if exception is thrown correctly

Closes issue 22552