### PR TITLE
Move IndicesStatsRequest to expose CommonStatsFlags directly (Closes 10096)

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsRequest.java
@@ -19,6 +19,7 @@
 
 package org.elasticsearch.action.admin.indices.stats;
 
+import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsRequest;
 import org.elasticsearch.action.admin.indices.stats.CommonStatsFlags.Flag;
 import org.elasticsearch.action.support.broadcast.BroadcastRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -51,6 +52,30 @@ public class IndicesStatsRequest extends BroadcastRequest<IndicesStatsRequest> {
      */
     public IndicesStatsRequest clear() {
         flags.clear();
+        return this;
+    }
+
+    public CommonStatsFlags flags() {
+        return flags;
+    }
+
+    /**
+     * Specify which flags to return
+     */
+    public IndicesStatsRequest flags(CommonStatsFlags flags) {
+        this.flags = flags;
+        return this;
+    }
+
+    /**
+     * Should stats be returned.
+     */
+    public IndicesStatsRequest flags(boolean flags) {
+        if (flags) {
+            this.flags.all();
+        } else {
+            this.flags.clear();
+        }
         return this;
     }
 


### PR DESCRIPTION
Closes issue 10096.
This change exposes the `CommonStatsFlags` property in `IndicesStatsRequest` in a similar fashion as `NodesStatsRequest`. 3 overloaded methods added allow access to the stats flags, toggling on/off all stats, and specifying which stats should be displayed.