### PR TITLE
Partial addition of test case for 22881

### DIFF
--- a/core/src/test/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregationBuilderTest.java
+++ b/core/src/test/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregationBuilderTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to Elasticsearch under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.elasticsearch.search.aggregations.bucket.range;
+
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.xcontent.ObjectParser;
+import org.elasticsearch.index.query.QueryParseContext;
+import org.elasticsearch.search.aggregations.AggregationBuilder;
+import org.elasticsearch.search.aggregations.AggregatorTestCase;
+import org.elasticsearch.search.aggregations.support.ValuesSourceParserHelper;
+import org.elasticsearch.test.ESTestCase;
+
+public class RangeAggregationBuilderTest extends AggregatorTestCase {
+
+    public void testBuilder() throws Exception {
+        
+        // Context was too complicated to replicate, however once that is fixed the remainder of the code should work.
+        QueryParseContext context = null;
+        
+        
+        try {
+            AggregationBuilder builder = RangeAggregationBuilder.parse("name", context);
+        } catch(ElasticsearchParseException e){
+            assertTrue(e.getMessage().equals("No [ranges] specified for the [name] aggregation"));
+        } catch (ArrayIndexOutOfBoundsException e){
+            fail("Throwing deprecated exception");
+        }
+        
+        fail("Didn't throw exception");
+    }
+    
+}


### PR DESCRIPTION
Added a test case for 22881. However, due to certain issues in how the context works and difficulty in replication, the context variable has been kept null. Once that is determined and the dependent pr (23241) merged, the test case will pass.