### PR TITLE
Snapshot size added to snapshot metadata 

### DIFF
--- a/core/src/main/java/org/elasticsearch/repositories/Repository.java
+++ b/core/src/main/java/org/elasticsearch/repositories/Repository.java
@@ -119,7 +119,7 @@ public interface Repository extends LifecycleComponent {
      * @return snapshot description
      */
     SnapshotInfo finalizeSnapshot(SnapshotId snapshotId, List<IndexId> indices, long startTime, String failure, int totalShards,
-                                  List<SnapshotShardFailure> shardFailures, long repositoryStateId);
+                                  List<SnapshotShardFailure> shardFailures, long repositoryStateId, List<ShardId> shardIds);
 
     /**
      * Deletes snapshot

--- a/core/src/main/java/org/elasticsearch/rest/action/cat/RestSnapshotAction.java
+++ b/core/src/main/java/org/elasticsearch/rest/action/cat/RestSnapshotAction.java
@@ -89,6 +89,7 @@ public class RestSnapshotAction extends AbstractCatAction {
                 .addCell("failed_shards", "alias:fs,failed_shards;text-align:right;desc:number of failed shards")
                 .addCell("total_shards", "alias:ts,total_shards;text-align:right;desc:number of total shards")
                 .addCell("reason", "default:false;alias:r,reason;desc:reason for failures")
+                .addCell("snapshot_size", "alias:sss, snapshot_size;desc:size of snapshot in bytes")
                 .endHeaders();
     }
 
@@ -117,7 +118,7 @@ public class RestSnapshotAction extends AbstractCatAction {
             table.addCell(snapshotStatus.failedShards());
             table.addCell(snapshotStatus.totalShards());
             table.addCell(snapshotStatus.reason());
-
+            table.addCell(snapshotStatus.snapshotSize());
             table.endRow();
         }
 

--- a/core/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/core/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -1504,7 +1504,7 @@ public class IndexShardTests extends IndexShardTestCase {
 
         @Override
         public SnapshotInfo finalizeSnapshot(SnapshotId snapshotId, List<IndexId> indices, long startTime, String failure, int totalShards,
-                                             List<SnapshotShardFailure> shardFailures, long repositoryStateId) {
+                                             List<SnapshotShardFailure> shardFailures, long repositoryStateId, List<ShardId> shardIds) {
             return null;
         }
 

--- a/core/src/test/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
+++ b/core/src/test/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
@@ -24,6 +24,7 @@ import com.carrotsearch.hppc.IntSet;
 
 import org.elasticsearch.action.ListenableActionFuture;
 import org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryResponse;
+import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotRequestBuilder;
 import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
 import org.elasticsearch.action.admin.cluster.snapshots.delete.DeleteSnapshotResponse;
 import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsResponse;
@@ -504,11 +505,28 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
 
 
         logger.info("--> start snapshot with default settings without a closed index - should fail");
-        CreateSnapshotResponse createSnapshotResponse = client().admin().cluster().prepareCreateSnapshot("test-repo", "test-snap-1")
-                .setIndices("test-idx-all", "test-idx-none", "test-idx-some")
-                .setWaitForCompletion(true).execute().actionGet();
+        logger.info("\n\n################ GOT TILL HERE -1\n\n");
+
+//        CreateSnapshotResponse createSnapshotResponse = client().admin().cluster().prepareCreateSnapshot("test-repo", "test-snap-1")
+//                .setIndices("test-idx-all", "test-idx-none", "test-idx-some")
+//                .setWaitForCompletion(true).execute().actionGet();
+
+        CreateSnapshotResponse createSnapshotResponse = null;
+        CreateSnapshotRequestBuilder snapshotBuilder = client().admin().cluster().prepareCreateSnapshot("test-repo", "test-snap-1");
+
+        logger.info("\n\n################ GOT TILL HERE 0\n\n");
+
+        snapshotBuilder.setIndices("test-idx-all", "test-idx-none", "test-idx-some");
+
+        logger.info("\n\n################ GOT TILL HERE 1\n\n");
+
+        createSnapshotResponse = snapshotBuilder.setWaitForCompletion(true).execute().actionGet();
+
+        logger.info("\n\n################ GOT TILL HERE 2\n\n");
+
         assertThat(createSnapshotResponse.getSnapshotInfo().state(), equalTo(SnapshotState.FAILED));
         assertThat(createSnapshotResponse.getSnapshotInfo().reason(), containsString("Indices don't have primary shards"));
+
 
         if (randomBoolean()) {
             logger.info("checking snapshot completion using status");


### PR DESCRIPTION
Closes issue 18543.

Currently, snapshots do not have a field describing the size of the snapshot itself. The inclusion of the size would be used to determine whether there is enough disk space on the target cluster before the execution of a restore. The changes include calculating the current size of the Shards in the Snapshot.

- Included the size of the snapshot by adding appropriate fields and a constructor to the `SnapshotInfo` class. 
- A method to calculate this size (in bytes) was also added.
- A parameter containing the list of `ShardIds` were added to the `finalizeSnapshot` method in order to calculate the size.