### PR TITLE
Add Integration Test for missing option in range, date_range, and ip_range aggregations. Resolve 17597.

### DIFF
--- a/docs/reference/aggregations/bucket/range-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/range-aggregation.asciidoc
@@ -53,6 +53,27 @@ Response:
 }
 --------------------------------------------------
 
+Adding the `missing` option to the `range` aggregation sets a default value for documents which do not have the specified value. All documents with the value missing will be added to the bucket corresponding to the value of the `missing` option. The following will place all documents without a `price` value in the `"from": 100` bucket:
+
+[source,js]
+--------------------------------------------------
+{
+    "aggs" : {
+        "price_ranges" : {
+            "range" : {
+                "field" : "price",
+                "missing" : "101",
+                "ranges" : [
+                    { "to" : 50 },
+                    { "from" : 50, "to" : 100 },
+                    { "from" : 100 }
+                ]
+            }
+        }
+    }
+}
+--------------------------------------------------
+
 ==== Keyed Response
 
 Setting the `keyed` flag to `true` will associate a unique string key with each bucket and return the ranges as a hash rather than an array:


### PR DESCRIPTION
**Changes**

- Integration Tests were added to ensure the `missing` option works correctly with `range`, `date_range`, and `ip_range` aggregations.
- Changes were made to to the `range-aggregation.asciidoc` documentation to mention that the `missing` option is supported for these aggregations.

**Notes on Issue 17597**

- The existing integration tests had some minor differences in naming and patterns (e.g. different methods used to setting up the indices, `assertThat` vs. `assertEquals`, etc.) ,  between `RangeIT.java`, `DateRangeIT.java`, and `IpRangeIT.java`. I tried to follow the schemes of each file to remain consistent with what was already there to maintain readability.
- Overall the `missing` option seems to work fine for these range aggregations, and this change should ensure that this will be officially supported and documented from now on.