### PR TITLE
Fix issue #21978 - Delimiter_payload

### DIFF
--- a/core/src/main/java/org/elasticsearch/indices/analysis/AnalysisModule.java
+++ b/core/src/main/java/org/elasticsearch/indices/analysis/AnalysisModule.java
@@ -227,7 +227,7 @@ public final class AnalysisModule {
         tokenFilters.register("stemmer", StemmerTokenFilterFactory::new);
         tokenFilters.register("word_delimiter", WordDelimiterTokenFilterFactory::new);
         tokenFilters.register("word_delimiter_graph", WordDelimiterGraphTokenFilterFactory::new);
-        tokenFilters.register("delimited_payload_filter", DelimitedPayloadTokenFilterFactory::new);
+        tokenFilters.register("delimited_payload", DelimitedPayloadTokenFilterFactory::new);
         tokenFilters.register("elision", ElisionTokenFilterFactory::new);
         tokenFilters.register("flatten_graph", FlattenGraphTokenFilterFactory::new);
         tokenFilters.register("keep", requriesAnalysisSettings(KeepWordFilterFactory::new));

--- a/core/src/main/java/org/elasticsearch/indices/analysis/PreBuiltTokenFilters.java
+++ b/core/src/main/java/org/elasticsearch/indices/analysis/PreBuiltTokenFilters.java
@@ -444,7 +444,7 @@ public enum PreBuiltTokenFilters {
         }
     },
 
-    DELIMITED_PAYLOAD_FILTER(CachingStrategy.ONE) {
+    DELIMITED_PAYLOAD(CachingStrategy.ONE) {
         @Override
         public TokenStream create(TokenStream tokenStream, Version version) {
             return new DelimitedPayloadTokenFilter(tokenStream, DelimitedPayloadTokenFilterFactory.DEFAULT_DELIMITER, DelimitedPayloadTokenFilterFactory.DEFAULT_ENCODER);

--- a/core/src/test/java/org/elasticsearch/action/termvectors/GetTermVectorsIT.java
+++ b/core/src/test/java/org/elasticsearch/action/termvectors/GetTermVectorsIT.java
@@ -420,10 +420,10 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
                 Settings.builder()
                         .put(indexSettings())
                         .put("index.analysis.analyzer.payload_test.tokenizer", "whitespace")
-                        .putArray("index.analysis.analyzer.payload_test.filter", "my_delimited_payload_filter")
-                        .put("index.analysis.filter.my_delimited_payload_filter.delimiter", delimiter)
-                        .put("index.analysis.filter.my_delimited_payload_filter.encoding", encodingString)
-                        .put("index.analysis.filter.my_delimited_payload_filter.type", "delimited_payload_filter")));
+                        .putArray("index.analysis.analyzer.payload_test.filter", "my_delimited_payload")
+                        .put("index.analysis.filter.my_delimited_payload.delimiter", delimiter)
+                        .put("index.analysis.filter.my_delimited_payload.encoding", encodingString)
+                        .put("index.analysis.filter.my_delimited_payload.type", "delimited_payload")));
 
         client().prepareIndex("test", "type1", Integer.toString(1))
                 .setSource(jsonBuilder().startObject().field("field", queryString).endObject()).execute().actionGet();

--- a/core/src/test/java/org/elasticsearch/script/IndexLookupIT.java
+++ b/core/src/test/java/org/elasticsearch/script/IndexLookupIT.java
@@ -539,7 +539,7 @@ public class IndexLookupIT extends ESIntegTestCase {
                         .putArray("index.analysis.analyzer.payload_int.filter", "delimited_int")
                         .put("index.analysis.filter.delimited_int.delimiter", "|")
                         .put("index.analysis.filter.delimited_int.encoding", "int")
-                        .put("index.analysis.filter.delimited_int.type", "delimited_payload_filter")));
+                        .put("index.analysis.filter.delimited_int.type", "delimited_payload")));
         indexRandom(true, client().prepareIndex("test", "type1", "1").setSource("int_payload_field", "a|1 b|2 b|3 c|4 d "), client()
                         .prepareIndex("test", "type1", "2").setSource("int_payload_field", "b|1 b|2 c|3 d|4 a "),
                 client().prepareIndex("test", "type1", "3").setSource("int_payload_field", "b|1 c|2 d|3 a|4 b "));
@@ -811,17 +811,17 @@ public class IndexLookupIT extends ESIntegTestCase {
                         .putArray("index.analysis.analyzer.payload_float.filter", "delimited_float")
                         .put("index.analysis.filter.delimited_float.delimiter", "|")
                         .put("index.analysis.filter.delimited_float.encoding", "float")
-                        .put("index.analysis.filter.delimited_float.type", "delimited_payload_filter")
+                        .put("index.analysis.filter.delimited_float.type", "delimited_payload")
                         .put("index.analysis.analyzer.payload_string.tokenizer", "whitespace")
                         .putArray("index.analysis.analyzer.payload_string.filter", "delimited_string")
                         .put("index.analysis.filter.delimited_string.delimiter", "|")
                         .put("index.analysis.filter.delimited_string.encoding", "identity")
-                        .put("index.analysis.filter.delimited_string.type", "delimited_payload_filter")
+                        .put("index.analysis.filter.delimited_string.type", "delimited_payload")
                         .put("index.analysis.analyzer.payload_int.tokenizer", "whitespace")
                         .putArray("index.analysis.analyzer.payload_int.filter", "delimited_int")
                         .put("index.analysis.filter.delimited_int.delimiter", "|")
                         .put("index.analysis.filter.delimited_int.encoding", "int")
-                        .put("index.analysis.filter.delimited_int.type", "delimited_payload_filter")
+                        .put("index.analysis.filter.delimited_int.type", "delimited_payload")
                         .put("index.number_of_shards", 1)));
         indexRandom(true, client().prepareIndex("test", "type1", "1").setSource("float_payload_field", "a|1 b|2 a|3 b "), client()
                         .prepareIndex("test", "type1", "2").setSource("string_payload_field", "a|a b|b a|a b "),

--- a/docs/reference/analysis/tokenfilters/delimited-payload-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/delimited-payload-tokenfilter.asciidoc
@@ -1,7 +1,7 @@
 [[analysis-delimited-payload-tokenfilter]]
 === Delimited Payload Token Filter
 
-Named `delimited_payload_filter`. Splits tokens into tokens and payload whenever a delimiter character is found.
+Named `delimited_payload`. Splits tokens into tokens and payload whenever a delimiter character is found.
 
 Example: "the|1 quick|2 fox|3" is split by default into tokens `the`, `quick`, and `fox` with payloads `1`, `2`, and `3` respectively.
 

--- a/test/framework/src/main/java/org/elasticsearch/AnalysisFactoryTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/AnalysisFactoryTestCase.java
@@ -309,7 +309,7 @@ public class AnalysisFactoryTestCase extends ESTestCase {
             case STEMMER:
                 luceneFactoryClazz = PorterStemFilterFactory.class;
                 break;
-            case DELIMITED_PAYLOAD_FILTER:
+            case DELIMITED_PAYLOAD:
                 luceneFactoryClazz = org.apache.lucene.analysis.payloads.DelimitedPayloadTokenFilterFactory.class;
                  break;
             case LIMIT:


### PR DESCRIPTION
Changed delimited_payload_filter to delimited_payload in all occurrences in the elasticsearch project.
(The issue said delimiter_payload_filter however the occurrences in the project were called delimited_payload_filter, so was spelt incorrectly in issue)
The changes were done in four classes and six test cases.
No comments were written as they were unnecessary.