### PR TITLE
Fix issue #21974 - Added fix for percentage encoding issue

### DIFF
--- a/core/src/main/java/org/elasticsearch/rest/RestRequest.java
+++ b/core/src/main/java/org/elasticsearch/rest/RestRequest.java
@@ -76,7 +76,19 @@ public abstract class RestRequest implements ToXContent.Params {
             this.rawPath = uri;
         } else {
             this.rawPath = uri.substring(0, pathEndPos);
-            RestUtils.decodeQueryString(uri, pathEndPos + 1, params);
+            
+            String percentUri;
+            // If the query ends with a %, change it to %25 rather than trying to resolve the encoding.
+            if (uri.substring(uri.length() - 1).equals("%"))
+            {
+                percentUri = uri + "25";
+            }
+            else
+            {
+                percentUri = uri;
+            }
+
+            RestUtils.decodeQueryString(percentUri, pathEndPos + 1, params);
         }
         this.params = params;
         this.headers = Collections.unmodifiableMap(headers);


### PR DESCRIPTION
Invalid queries that end with a "%" symbol such as http://localhost9200/?% (query part: /?%), threw out an exception to the server 
and did not give a formatted message to the client. Fix has been implemented so that a formatted error message will be sent to the client.

The fix was implemented an if-else statement that swapped any "%" symbol that is found at the end of a query 
to "%25" (the correct encoding for "%" symbol). The modified query is then passed back to Elasticsearch which carries on with the usual functionality

