### PR TITLE
Fix issue #23231

### DIFF
--- a/Coordination.md
+++ b/Coordination.md
@@ -65,4 +65,4 @@ Issue number: group name (no links to elasticsearch, just the number - sort by i
 * 23646: Chicken Nugget Trio
 * 23664: Random 1
 * 23673: Random 1
-
+* 23231: Random 2

--- a/client/rest/src/main/java/org/elasticsearch/client/RestClientBuilder.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/RestClientBuilder.java
@@ -204,6 +204,9 @@ public final class RestClientBuilder {
                 //default settings for connection pooling may be too constraining
                 .setMaxConnPerRoute(DEFAULT_MAX_CONN_PER_ROUTE)
                 .setMaxConnTotal(DEFAULT_MAX_CONN_TOTAL)
+            	// use system properties when it is validate 
+                //this help on reindex as it uses the RestClient internally 
+                //and can be easily configured to trust different certificates
                 .useSystemProperties();
         if (httpClientConfigCallback != null) {
             httpClientBuilder = httpClientConfigCallback.customizeHttpClient(httpClientBuilder);

--- a/client/rest/src/main/java/org/elasticsearch/client/RestClientBuilder.java
+++ b/client/rest/src/main/java/org/elasticsearch/client/RestClientBuilder.java
@@ -202,7 +202,9 @@ public final class RestClientBuilder {
 
         HttpAsyncClientBuilder httpClientBuilder = HttpAsyncClientBuilder.create().setDefaultRequestConfig(requestConfigBuilder.build())
                 //default settings for connection pooling may be too constraining
-                .setMaxConnPerRoute(DEFAULT_MAX_CONN_PER_ROUTE).setMaxConnTotal(DEFAULT_MAX_CONN_TOTAL);
+                .setMaxConnPerRoute(DEFAULT_MAX_CONN_PER_ROUTE)
+                .setMaxConnTotal(DEFAULT_MAX_CONN_TOTAL)
+                .useSystemProperties();
         if (httpClientConfigCallback != null) {
             httpClientBuilder = httpClientConfigCallback.customizeHttpClient(httpClientBuilder);
         }

--- a/client/rest/src/test/java/org/elasticsearch/client/RestClientBuilderTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/RestClientBuilderTests.java
@@ -178,10 +178,14 @@ public class RestClientBuilderTests extends RestClientTestCase {
     }
     
     public void testSetSystemProperties(){
+    	//this unit test tests if the ClientBuilder build client according to the system properties
+    	//set the http.maxConnections properties to invalid value 
+    	//this will cause NumberFormatException  when building the client with system properties
     	System.setProperty("http.maxConnections", "??");   	
     	try (RestClient restClient = RestClient.builder(new HttpHost("localhost", 9200)).build()) {       
     			 fail("should have failed");    
 		} catch (NumberFormatException | IOException e1) {
+			//reset the system property to avoid break other test caeses
 			System.clearProperty("http.maxConnections");
 		} 
 	 

--- a/client/rest/src/test/java/org/elasticsearch/client/RestClientBuilderTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/RestClientBuilderTests.java
@@ -176,5 +176,15 @@ public class RestClientBuilderTests extends RestClientTestCase {
             assertThat(e.getMessage(), containsString(pathPrefix));
         }
     }
+    
+    public void testSetSystemProperties(){
+    	System.setProperty("http.maxConnections", "??");   	
+    	try (RestClient restClient = RestClient.builder(new HttpHost("localhost", 9200)).build()) {       
+    			 fail("should have failed");    
+		} catch (NumberFormatException | IOException e1) {
+			System.clearProperty("http.maxConnections");
+		} 
+	 
+    }
 
 }

--- a/client/rest/src/test/java/org/elasticsearch/client/RestClientBuilderTests.java
+++ b/client/rest/src/test/java/org/elasticsearch/client/RestClientBuilderTests.java
@@ -181,7 +181,7 @@ public class RestClientBuilderTests extends RestClientTestCase {
     	//this unit test tests if the ClientBuilder build client according to the system properties
     	//set the http.maxConnections properties to invalid value 
     	//this will cause NumberFormatException  when building the client with system properties
-    	System.setProperty("http.maxConnections", "??");   	
+    	System.setProperty("http.maxConnections","invilad value");
     	try (RestClient restClient = RestClient.builder(new HttpHost("localhost", 9200)).build()) {       
     			 fail("should have failed");    
 		} catch (NumberFormatException | IOException e1) {


### PR DESCRIPTION
I changed the setting for the RestClient from defualt to the  JVM system defaults for SSL . This helps on reindex as it uses the RestClient internally and can be easily configured to trust different certificates.

Sourcecode changed in method **createHttpClient()** of the file **RestClientBuilder.java** . I use useSysstemProerties() at the end to overwrite the defaults setting. More detailed documentation is [here](https://hc.apache.org/httpcomponents-asyncclient-dev/httpasyncclient/apidocs/org/apache/http/impl/nio/client/HttpAsyncClientBuilder.html). 

I wrote a unit test to test if the client is set up according to system properties in class **TestClientBuilder.java**. I set the system properties wrongly on purpose, and test if the Client is built wrongly. If the Client is using the system properties the building process will fail.
