### PR TITLE
Updated text in errors related to incorrect version: #21278

### DIFF
--- a/core/src/main/java/org/elasticsearch/index/VersionType.java
+++ b/core/src/main/java/org/elasticsearch/index/VersionType.java
@@ -37,7 +37,8 @@ public enum VersionType implements Writeable {
             if (expectedVersion == Versions.MATCH_DELETED) {
                 return "document already exists (current version [" + currentVersion + "])";
             }
-            return "current version [" + currentVersion + "] is different than the one provided [" + expectedVersion + "]";
+            return "current version [" + currentVersion + "] is different than the one provided [" + expectedVersion + "]: document " +
+                "not found";
         }
 
         @Override
@@ -47,6 +48,10 @@ public enum VersionType implements Writeable {
 
         @Override
         public String explainConflictForReads(long currentVersion, long expectedVersion) {
+            if(currentVersion == -1) {
+                return "current version [" + currentVersion + "] is different than the one provided [" + expectedVersion + "]: document " +
+                    "not found";
+            }
             return "current version [" + currentVersion + "] is different than the one provided [" + expectedVersion + "]";
         }
 
@@ -122,7 +127,11 @@ public enum VersionType implements Writeable {
 
         @Override
         public String explainConflictForReads(long currentVersion, long expectedVersion) {
-            return "current version [" + currentVersion + "] is different than the one provided [" + expectedVersion + "]";
+            if(currentVersion == -1){
+                return "current version [" + currentVersion + "] is different than the one provided [" + expectedVersion + "]: document " +
+                    "not found" ;
+            }
+            return "current version [" + currentVersion + "] is different than the one provided [" + expectedVersion + "]" ;
         }
 
         @Override
@@ -177,6 +186,10 @@ public enum VersionType implements Writeable {
 
         @Override
         public String explainConflictForReads(long currentVersion, long expectedVersion) {
+            if(currentVersion == -1) {
+                return "current version [" + currentVersion + "] is different than the one provided [" + expectedVersion + "]: document " +
+                    "not found";
+            }
             return "current version [" + currentVersion + "] is different than the one provided [" + expectedVersion + "]";
         }
 


### PR DESCRIPTION
This pull requests closes issue 21278.
The change fixes a problem where version number is -1, the error message was not very informative (it should indicate that a file is not found). The error message now contains informative text when required.

_Changes:_
-Updated text in errors related to incorrect version - now indicates that the document was not found
-Updated text in errors related to incorrect version - now indicates that the document was not found only when version is -1, rather than all the time
-Updated VersionType.java to have line widths of less than 140

