### PR TITLE
Fixing Issue# 21802: 'require_field_match' parameter should accept "true"|"false"

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/xcontent/AbstractObjectParser.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/AbstractObjectParser.java
@@ -37,6 +37,8 @@ import java.util.function.BiFunction;
 public abstract class AbstractObjectParser<Value, Context>
         implements BiFunction<XContentParser, Context, Value>, ContextParser<Context, Value> {
 
+	protected XContentParser xContentParser=null;
+	
     /**
      * Declare some field. Usually it is easier to use {@link #declareString(BiConsumer, ParseField)} or
      * {@link #declareObject(BiConsumer, ContextParser, ParseField)} rather than call this directly.

--- a/core/src/main/java/org/elasticsearch/common/xcontent/ObjectParser.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/ObjectParser.java
@@ -142,6 +142,11 @@ public final class ObjectParser<Value, Context> extends AbstractObjectParser<Val
      */
     public Value parse(XContentParser parser, Value value, Context context) throws IOException {
         XContentParser.Token token;
+        
+        if(parser!=null){
+        	this.xContentParser=parser;
+        }
+        
         if (parser.currentToken() == XContentParser.Token.START_OBJECT) {
             token = parser.currentToken();
         } else {
@@ -164,8 +169,15 @@ public final class ObjectParser<Value, Context> extends AbstractObjectParser<Val
                 if (fieldParser == null) {
                     assert ignoreUnknownFields : "this should only be possible if configured to ignore known fields";
                     parser.skipChildren(); // noop if parser points to a value, skips children if parser is start object or start array
-                } else {
+                } else {	
+                	/*
+                	 * Fixing Issue:21802
+                	 * Date:24 Mar, 2017
+                	 * Add local variable "parser" to match the modified method assertSupports. "parser" is used to 
+                	 * get current value (according to the issue here requires String value).
+                	 * */
                     fieldParser.assertSupports(name, token, currentFieldName);
+                    
                     parseSub(parser, fieldParser, currentFieldName, value, context);
                 }
                 fieldParser = null;
@@ -414,15 +426,34 @@ public final class ObjectParser<Value, Context> extends AbstractObjectParser<Val
             this.type = type;
         }
 
-        void assertSupports(String parserName, XContentParser.Token token, String currentFieldName) {
-            if (parseField.match(currentFieldName) == false) {
-                throw new IllegalStateException("[" + parserName  + "] parsefield doesn't accept: " + currentFieldName);
-            }
-            if (supportedTokens.contains(token) == false) {
-                throw new IllegalArgumentException(
-                        "[" + parserName + "] " + currentFieldName + " doesn't support values of type: " + token);
-            }
-        }
+        /*
+    	 * Fixing Issue:21802
+    	 * Date:24 Mar, 2017
+    	 * Add a new formal parameter with type of XContentParser to the methods. 
+    	 * Add new logic in order to filter String value "true" and "false", to ensure that these values will 
+    	 * not trigger an IllegalArgumentException. 
+    	 * */
+        void assertSupports(String parserName, XContentParser.Token token,
+				String currentFieldName) {
+			if (parseField.match(currentFieldName) == false) {
+				throw new IllegalStateException("[" + parserName + "] parsefield doesn't accept: " + currentFieldName);
+			}
+			if (supportedTokens.contains(token) == false) {
+				if (token == XContentParser.Token.VALUE_STRING) {
+					try {
+						if ((xContentParser.text().equals("true")) || (xContentParser.text().equals("false"))) {
+							xContentParser=null;
+                            return;
+						}
+					} catch (IOException e) {
+						e.printStackTrace();
+					}
+				}
+
+				throw new IllegalArgumentException(
+						"[" + parserName + "] " + currentFieldName + " doesn't support values of type: " + token);
+			}
+		}
 
         @Override
         public String toString() {

--- a/core/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/AbstractHighlighterBuilder.java
+++ b/core/src/main/java/org/elasticsearch/search/fetch/subphase/highlight/AbstractHighlighterBuilder.java
@@ -148,6 +148,66 @@ public abstract class AbstractHighlighterBuilder<HB extends AbstractHighlighterB
         requireFieldMatch(in.readOptionalBoolean());
     }
 
+    /*
+	 * Fixing Issue:21802
+	 * Date:24 Mar, 2017
+	 * This static block is called by its subclass HighlightBuilder, after creating a highlight object 
+	 * parser, it continues to read json commands and allocates them to the fields in this object, and 
+	 * will check the syntax of these commands.
+	 * */
+    static <HB extends AbstractHighlighterBuilder<HB>> BiFunction<QueryParseContext, HB, HB> setupParser(
+            ObjectParser<HB, QueryParseContext> parser) {
+        parser.declareStringArray(fromList(String.class, HB::preTags), PRE_TAGS_FIELD);
+        parser.declareStringArray(fromList(String.class, HB::postTags), POST_TAGS_FIELD);
+        parser.declareString(HB::order, ORDER_FIELD);
+        parser.declareBoolean(HB::highlightFilter, HIGHLIGHT_FILTER_FIELD);
+        parser.declareInt(HB::fragmentSize, FRAGMENT_SIZE_FIELD);
+        parser.declareInt(HB::numOfFragments, NUMBER_OF_FRAGMENTS_FIELD);
+        parser.declareBoolean(HB::requireFieldMatch, REQUIRE_FIELD_MATCH_FIELD);
+        parser.declareString(HB::boundaryScannerType, BOUNDARY_SCANNER_FIELD);
+        parser.declareInt(HB::boundaryMaxScan, BOUNDARY_MAX_SCAN_FIELD);
+        parser.declareString((HB hb, String bc) -> hb.boundaryChars(bc.toCharArray()) , BOUNDARY_CHARS_FIELD);
+        parser.declareString(HB::boundaryScannerLocale, BOUNDARY_SCANNER_LOCALE_FIELD);
+        parser.declareString(HB::highlighterType, TYPE_FIELD);
+        parser.declareString(HB::fragmenter, FRAGMENTER_FIELD);
+        parser.declareInt(HB::noMatchSize, NO_MATCH_SIZE_FIELD);
+        parser.declareBoolean(HB::forceSource, FORCE_SOURCE_FIELD);
+        parser.declareInt(HB::phraseLimit, PHRASE_LIMIT_FIELD);
+        parser.declareObject(HB::options, (XContentParser p, QueryParseContext c) -> {
+            try {
+                return p.map();
+            } catch (IOException e) {
+                throw new RuntimeException("Error parsing options", e);
+            }
+        }, OPTIONS_FIELD);
+        parser.declareObject(HB::highlightQuery, (XContentParser p, QueryParseContext c) -> {
+            try {
+                return c.parseInnerQueryBuilder();
+            } catch (IOException e) {
+                throw new RuntimeException("Error parsing query", e);
+            }
+        }, HIGHLIGHT_QUERY_FIELD);
+        return (QueryParseContext c, HB hb) -> {
+            try {           	
+            	/*
+            	 * Fixing Issue:21802
+            	 * Date:24 Mar, 2017
+            	 * This method commence a syntax checking on the inputted json commands. It
+            	 * guarantees that no syntax error exists before searching any data.
+            	 * */
+                parser.parse(c.parser(), hb, c);
+                
+                if (hb.preTags() != null && hb.postTags() == null) {
+                    throw new ParsingException(c.parser().getTokenLocation(),
+                            "pre_tags are set but post_tags are not set");
+                }
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            return hb;
+        };
+    }
+    
     /**
      * write common parameters to {@link StreamOutput}
      */
@@ -593,51 +653,7 @@ public abstract class AbstractHighlighterBuilder<HB extends AbstractHighlighterB
         }
     }
 
-    static <HB extends AbstractHighlighterBuilder<HB>> BiFunction<QueryParseContext, HB, HB> setupParser(
-            ObjectParser<HB, QueryParseContext> parser) {
-        parser.declareStringArray(fromList(String.class, HB::preTags), PRE_TAGS_FIELD);
-        parser.declareStringArray(fromList(String.class, HB::postTags), POST_TAGS_FIELD);
-        parser.declareString(HB::order, ORDER_FIELD);
-        parser.declareBoolean(HB::highlightFilter, HIGHLIGHT_FILTER_FIELD);
-        parser.declareInt(HB::fragmentSize, FRAGMENT_SIZE_FIELD);
-        parser.declareInt(HB::numOfFragments, NUMBER_OF_FRAGMENTS_FIELD);
-        parser.declareBoolean(HB::requireFieldMatch, REQUIRE_FIELD_MATCH_FIELD);
-        parser.declareString(HB::boundaryScannerType, BOUNDARY_SCANNER_FIELD);
-        parser.declareInt(HB::boundaryMaxScan, BOUNDARY_MAX_SCAN_FIELD);
-        parser.declareString((HB hb, String bc) -> hb.boundaryChars(bc.toCharArray()) , BOUNDARY_CHARS_FIELD);
-        parser.declareString(HB::boundaryScannerLocale, BOUNDARY_SCANNER_LOCALE_FIELD);
-        parser.declareString(HB::highlighterType, TYPE_FIELD);
-        parser.declareString(HB::fragmenter, FRAGMENTER_FIELD);
-        parser.declareInt(HB::noMatchSize, NO_MATCH_SIZE_FIELD);
-        parser.declareBoolean(HB::forceSource, FORCE_SOURCE_FIELD);
-        parser.declareInt(HB::phraseLimit, PHRASE_LIMIT_FIELD);
-        parser.declareObject(HB::options, (XContentParser p, QueryParseContext c) -> {
-            try {
-                return p.map();
-            } catch (IOException e) {
-                throw new RuntimeException("Error parsing options", e);
-            }
-        }, OPTIONS_FIELD);
-        parser.declareObject(HB::highlightQuery, (XContentParser p, QueryParseContext c) -> {
-            try {
-                return c.parseInnerQueryBuilder();
-            } catch (IOException e) {
-                throw new RuntimeException("Error parsing query", e);
-            }
-        }, HIGHLIGHT_QUERY_FIELD);
-        return (QueryParseContext c, HB hb) -> {
-            try {
-                parser.parse(c.parser(), hb, c);
-                if (hb.preTags() != null && hb.postTags() == null) {
-                    throw new ParsingException(c.parser().getTokenLocation(),
-                            "pre_tags are set but post_tags are not set");
-                }
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-            return hb;
-        };
-    }
+    
 
     @Override
     public final int hashCode() {

--- a/docs/reference/search/request/highlighting.asciidoc
+++ b/docs/reference/search/request/highlighting.asciidoc
@@ -484,6 +484,9 @@ be highlighted regardless of whether the query matched specifically on them.
 The default behaviour is `true`, meaning that only fields that hold a query
 match will be highlighted.
 
+When assign a value to `require_field_match` parameter, both Boolean value 
+true|false and String value "true"|"false" can be accepted to execute a query.
+
 [source,js]
 --------------------------------------------------
 GET /_search


### PR DESCRIPTION
This pull request contains following changes:

1. Functionality changes: Fix issue 21802
Description: By modifying logics in ObjectParser class, now String value "true"|"false" in highlight searching can be accepted, and it will not trigger an illegal argument exception.
File involved: core/org/elasticsearch/common/xcontent/ObjectParser.java,                             core/org/elasticsearch/common/xcontent/AbstractObjectParser.java.

2. Code Comments for issue 21802
Description: Add comments for the part of code which has been modified, together with some descriptions of mechanisms of highlight searching function, which may helpful for future contributors.
File involved: core/org/elasticsearch/common/xcontent/ObjectParser.java
core/org/elasticsearch/search/fetch/subphase/highlight/AbstractHighlightBuilder.java,                             core/org/elasticsearch/search/fetch/subphase/highlight/HighlightBuilder.java.

3. Refactoring for issue 21802
Description: <1>Add global variables xContentParser to read and record inputs, so that the declaration of assertSupport method in ObjectParser class does not need to be changed. It is convenient to acquire original json commands for syntax checking purposes by calling its methods, while the highlight searching function remains unchanged.
<2>Sort out some static blocks in HighlightBuilder class and its super class and move them to the front. These static blocks are used to create ObjectParser object, reading and checking inputs, and will be initialized in the highest priority when a search request is executed, comments about the function of these blocks have been added as well. 
File involved: core/org/elasticsearch/common/xcontent/ObjectParser.java,
core/org/elasticsearch/common/xcontent/AbstractObjectParser.java,
core/org/elasticsearch/search/fetch/subphase/highlight/AbstractHighlightBuilder.java,                             core/org/elasticsearch/search/fetch/subphase/highlight/HighlightBuilder.java,

Additional - 3 commits in total, and have been squashed into one. Modified code has been tested.