### PR TITLE
Deprecate support for .json in 2.4.0

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/settings/loader/JsonSettingsLoader.java
+++ b/core/src/main/java/org/elasticsearch/common/settings/loader/JsonSettingsLoader.java
@@ -24,7 +24,11 @@ import org.elasticsearch.common.xcontent.XContentType;
 /**
  * Settings loader that loads (parses) the settings in a json format by flattening them
  * into a map.
+ *
+ * @deprecated JSON will be deprecated as of ES 2.4 and will be removed in ES 5.0 because YAML will be used instead. Replaced by
+ *      {@link org.elasticsearch.common.settings.loader.YamlSettingsLoader}
  */
+@Deprecated
 public class JsonSettingsLoader extends XContentSettingsLoader {
 
     @Override

--- a/core/src/main/java/org/elasticsearch/common/xcontent/XContentFactory.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/XContentFactory.java
@@ -44,14 +44,22 @@ public class XContentFactory {
 
     /**
      * Returns a content builder using JSON format ({@link org.elasticsearch.common.xcontent.XContentType#JSON}.
+     *
+     * @deprecated JSON will be deprecated as of ES 2.4 and will be removed in ES 5.0 because YAML will be used instead. Replaced by
+     *      {@link #yamlBuilder()}
      */
+    @Deprecated
     public static XContentBuilder jsonBuilder() throws IOException {
         return contentBuilder(XContentType.JSON);
     }
 
     /**
      * Constructs a new json builder that will output the result into the provided output stream.
+     *
+     * @deprecated JSON will be deprecated as of ES 2.4 and will be removed in ES 5.0 because YAML will be used instead. Replaced by
+     *      {@link #yamlBuilder(OutputStream)}
      */
+    @Deprecated
     public static XContentBuilder jsonBuilder(OutputStream os) throws IOException {
         return new XContentBuilder(JsonXContent.jsonXContent, os);
     }

--- a/core/src/main/java/org/elasticsearch/common/xcontent/json/JsonXContent.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/json/JsonXContent.java
@@ -31,7 +31,11 @@ import java.io.*;
 
 /**
  * A JSON based content implementation using Jackson.
+ *
+ * @deprecated JSON will be deprecated as of ES 2.4 and will be removed in ES 5.0 because YAML will be used instead. Replaced by
+ *      {@link org.elasticsearch.common.xcontent.yaml.YamlXContent}
  */
+@Deprecated
 public class JsonXContent implements XContent {
 
     public static XContentBuilder contentBuilder() throws IOException {

--- a/core/src/main/java/org/elasticsearch/common/xcontent/json/JsonXContentGenerator.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/json/JsonXContentGenerator.java
@@ -39,8 +39,10 @@ import java.io.InputStream;
 import java.io.OutputStream;
 
 /**
- *
+ * @deprecated JSON will be deprecated as of ES 2.4 and will be removed in ES 5.0 because YAML will be used instead. Replaced by
+ *      {@link org.elasticsearch.common.xcontent.yaml.YamlXContentGenerator}
  */
+@Deprecated
 public class JsonXContentGenerator implements XContentGenerator {
 
     /** Generator used to write content **/

--- a/core/src/main/java/org/elasticsearch/common/xcontent/json/JsonXContentParser.java
+++ b/core/src/main/java/org/elasticsearch/common/xcontent/json/JsonXContentParser.java
@@ -33,8 +33,10 @@ import java.io.IOException;
 import java.nio.CharBuffer;
 
 /**
- *
+ * @deprecated JSON will be deprecated as of ES 2.4 and will be removed in ES 5.0 because YAML will be used instead. Replaced by
+ *      {@link org.elasticsearch.common.xcontent.yaml.YamlXContentParser}
  */
+@Deprecated
 public class JsonXContentParser extends AbstractXContentParser {
 
     final JsonParser parser;


### PR DESCRIPTION
This PR fixes the second sub-issue in issue 19391 : "deprecate support for .json in 2.4.0"

JSON is deprecated for ES 2.4.0 as support for it will be removed in ES 5.0
YAML should be used in its place.

Changes: 
- Added Deprecation annotation to relevant classes and methods involving JSON content type
- Added JavaDoc documentation to explain why something is deprecated