### PR TITLE
Fixed Issue #15965 - Included further information for exceptions when…

### DIFF
--- a/core/src/main/java/org/elasticsearch/common/geo/GeoPoint.java
+++ b/core/src/main/java/org/elasticsearch/common/geo/GeoPoint.java
@@ -111,8 +111,13 @@ public final class GeoPoint {
     }
 
     public GeoPoint resetFromGeoHash(String geohash) {
-        final long hash = mortonEncode(geohash);
-        return this.reset(GeoPointField.decodeLatitude(hash), GeoPointField.decodeLongitude(hash));
+        int fullstop = geohash.indexOf('.');
+        if (fullstop != -1) {
+            throw new IllegalArgumentException("The malformed geo-point field with value of [" + geohash + "] contains a non-valid geohash character '.'.");
+        } else {
+            final long hash = mortonEncode(geohash);
+            return this.reset(GeoPointField.decodeLatitude(hash), GeoPointField.decodeLongitude(hash));
+        }
     }
 
     public GeoPoint resetFromGeoHash(long geohashLong) {

--- a/core/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
+++ b/core/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
@@ -218,10 +218,10 @@ public class GeoPointFieldMapper extends FieldMapper implements ArrayValueMapper
 
         if (ignoreMalformed.value() == false) {
             if (point.lat() > 90.0 || point.lat() < -90.0) {
-                throw new IllegalArgumentException("illegal latitude value [" + point.lat() + "] for " + name());
+                throw new IllegalArgumentException("The malformed geo-point field: " + name() +"[" + point.lat() + "," + point.lon() + "]" +" has an illegal latitude value.");
             }
             if (point.lon() > 180.0 || point.lon() < -180) {
-                throw new IllegalArgumentException("illegal longitude value [" + point.lon() + "] for " + name());
+                throw new IllegalArgumentException("The malformed geo-point field: " + name() +"[" + point.lat() + "," + point.lon() + "]" +" has an illegal longitude value.");
             }
         } else {
             GeoUtils.normalizePoint(point);


### PR DESCRIPTION
… a geo-point type field is entered incorrectly

This PR fixes issues for exceptions not giving you sufficient information when you enter a geo-point type field in an incorrect format.

Changes:
- Changed the original exception message to include further information
- Added in another exception

Testing:
I tested my changes by entering in the following commands

1: Command for mapping the fields to the geo-point type
curl -XPUT 'http://localhost:9200/attraction?pretty' -H'Content-Type: application/json' -d'
{
  "mappings": {
    "restaurant": {
      "properties": {
        "location": {
          "type": "geo_point"
        }
      }
    }
  }
}'

2: Command for putting incorrect geo-point (This should throw the exception error):
curl -XPUT 'http://localhost:9200/attraction/restaurant/2?pretty' -H 'Content-Type: application/json' -d '
{
    "location": "127.0.0.1"
}'

Valid geo-point field is "lat, lon" or enter a geo-hash as a string. 

Has been tested using the testing suite.

 
<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS that we support](https://www.elastic.co/support/matrix#show_os)?
