### PR TITLE
Fix issue #17853 - POST index/_settings with body produces wrong exception

### DIFF
--- a/core/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexRequest.java
+++ b/core/src/main/java/org/elasticsearch/action/admin/indices/get/GetIndexRequest.java
@@ -77,7 +77,16 @@ public class GetIndexRequest extends ClusterInfoRequest<GetIndexRequest> {
                     return feature;
                 }
             }
-            throw new IllegalArgumentException("No endpoint or operation is available at [" + name + "]");
+            // check the request body contains empty content or not
+            String noSpacesName = name.replaceAll("\\s+","");
+        	if(noSpacesName.contains("{}") || noSpacesName.contains("''"))
+        	{
+        		throw new IllegalArgumentException("The empty body is not allowed");
+        	}
+        	else
+        	{
+        		throw new IllegalArgumentException("No endpoint or operation is available at [" + name + "]");
+        	}
         }
 
         public static Feature fromId(byte id) {


### PR DESCRIPTION
- added if statement to check the request body is empty or not
- created content for empty body exception 
([The Issue link is here](https://github.com/elastic/elasticsearch/issues/17853))

Before this update
Sending an empty body results a wrong / confused exception

After update
The exception can response that the empty body is not allowed.
