### PR TITLE
Fix 23823 Coerce Ingest Simulate document properties to string

### DIFF
--- a/core/src/main/java/org/elasticsearch/ingest/ConfigurationUtils.java
+++ b/core/src/main/java/org/elasticsearch/ingest/ConfigurationUtils.java
@@ -50,7 +50,8 @@ public final class ConfigurationUtils {
     /**
      * Returns and removes the specified property from the specified configuration map.
      *
-     * If the property value isn't of type string an {@link ElasticsearchParseException} is thrown.
+     * If the property value is of type integer, it will be coerced to a string
+     * If the property value isn't of type string or integer, an {@link ElasticsearchParseException} is thrown.
      * If the property is missing an {@link ElasticsearchParseException} is thrown
      */
     public static String readStringProperty(String processorType, String processorTag, Map<String, Object> configuration,
@@ -61,7 +62,8 @@ public final class ConfigurationUtils {
     /**
      * Returns and removes the specified property from the specified configuration map.
      *
-     * If the property value isn't of type string a {@link ElasticsearchParseException} is thrown.
+     * If the property value is of type integer, it will be coerced to a string
+     * If the property value isn't of type string or integer, a {@link ElasticsearchParseException} is thrown.
      * If the property is missing and no default value has been specified a {@link ElasticsearchParseException} is thrown
      */
     public static String readStringProperty(String processorType, String processorTag, Map<String, Object> configuration,
@@ -82,7 +84,10 @@ public final class ConfigurationUtils {
         if (value instanceof String) {
             return (String) value;
         }
-        throw newConfigurationException(processorType, processorTag, propertyName, "property isn't a string, but of type [" +
+        if (value instanceof Integer) {
+            return Integer.toString((Integer)value);
+        }
+        throw newConfigurationException(processorType, processorTag, propertyName, "property isn't a string or integer, but of type [" +
             value.getClass().getName() + "]");
     }
 


### PR DESCRIPTION
Will coerce document properties defined as a number to a string when using Simulate Pipeline API.
Does this by converting value parsed from JSON document definition to String if it is of type Integer.
Will only convert if type is Integer (preventing invalid types parsed from JSON document definition)
Value extracted from configuration map is of type object, so javadocs updated to reflect the types that object is allowed to be 

May cause merge conflicts with other pull requests fixing issues with 'ingest' label as similar files are likely to have been modified. Take care when attempting to merge into master.