### PR TITLE
Fix 23824 Handle ingest inline scripts more appropriately

### DIFF
--- a/core/src/main/java/org/elasticsearch/ingest/ConfigurationUtils.java
+++ b/core/src/main/java/org/elasticsearch/ingest/ConfigurationUtils.java
@@ -32,6 +32,7 @@ import java.util.Map;
 public final class ConfigurationUtils {
 
     public static final String TAG_KEY = "tag";
+    public static final String SCRIPT_KEY = "script";
 
     private ConfigurationUtils() {
     }
@@ -251,6 +252,12 @@ public final class ConfigurationUtils {
                 for (Map.Entry<String, Map<String, Object>> entry : processorConfigWithKey.entrySet()) {
                     try {
                         processors.add(readProcessor(processorFactories, entry.getKey(), entry.getValue()));
+                    } catch (ClassCastException ce) {
+                        if(entry.getKey().equals(SCRIPT_KEY)){
+                            exception = newConfigurationException(null, null, entry.getKey(), "Must be an Object. Short form scripting not allowed");
+                        } else {
+                            exception = ExceptionsHelper.useOrSuppress(exception, ce);
+                        }
                     } catch (Exception e) {
                         exception = ExceptionsHelper.useOrSuppress(exception, e);
                     }

--- a/docs/reference/ingest/ingest-node.asciidoc
+++ b/docs/reference/ingest/ingest-node.asciidoc
@@ -1661,6 +1661,16 @@ numeric fields `field_a` and `field_b` multiplied by the parameter param_c:
 }
 --------------------------------------------------
 
+note: processors expect properties to be defined as objects, so short form scripting like in the following
+example would not be allowed
+
+[source,js]
+--------------------------------------------------
+{
+  "script":  "ctx.foo='bar'" //not allowed
+}
+--------------------------------------------------
+
 
 [[set-processor]]
 === Set Processor


### PR DESCRIPTION
Will deliver a more useful error message to user when using they specify
a short form script (not allowed) with the Pipeline Simulate API.
No commenting necessary for this pull request
Documentation file updated

May cause conflicts with the changes made in pull request 172 or any pull requests
attempting to fix issue 23823 as similar files are being modified. 

May also cause merge conflicts with pull requests fixing issues with 'ingest' label as similar files are likely to have been modified. Again take care when attempting to merge into master.